### PR TITLE
Changed `bs-platform` from "dependencies" to "peerDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/Gregoirevda/reason-apollo.git"
   },
   "scripts": {
-    "test:ci": "bsb -make-world"
+    "test:ci": "bsb -make-world",
+    "prepare": "npm link bs-platform"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "reason-react": "^0.2.4"
   },
-  "dependencies": {
+  "peerDependencies": {
     "bs-platform": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.0.0",
-    "apollo-link-http": "^1.0.0"
+    "apollo-link-http": "^1.0.0",
+    "bs-platform": "^2.0.0"
   },
   "keywords": [
     "Reason",
@@ -23,8 +24,5 @@
   "author": "Grégoire Van der Auwermeulen <gregoirevandera@gmail.com>",
   "devDependencies": {
     "reason-react": "^0.2.4"
-  },
-  "peerDependencies": {
-    "bs-platform": "^2.0.0"
   }
 }


### PR DESCRIPTION
It is a good practice to add 'bs-platform' as "peerDependency" so it doesn't trigger rebuilding bucklescript for every package, which would be slow and undesirable. The standard practice in Reason is to 'link' the global bs-platform package once per project instead so only a single `bs-platform` package is used without rebuilding it. People using Reason are used to this.