### PR TITLE
Add very basic mutation support.

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -2,7 +2,11 @@ open ReasonApolloTypes;
 
 type variableTypeToBeDefined;
 type queryObj = {. "query": queryString, "variables": variableTypeToBeDefined};
-type generatedApolloClient = {. "query": [@bs.meth] (queryObj => string)};
+type mutateObj = {. "mutation": queryString, "variables": variableTypeToBeDefined};
+type generatedApolloClient = {.
+  "query": [@bs.meth] (queryObj => string),
+  "mutate": [@bs.meth] (mutateObj => string)
+};
 type clientOptions = {. "cache": unit, "link": unit};
 type linkOptions = {. "uri": string};
 
@@ -20,7 +24,12 @@ module type ApolloClientCast = {
 /* Cast the apolloClient, with the known variable type when called */
 module Cast = (ApolloClientCast:ApolloClientCast) => {
   type queryObj = {. "query": queryString, "variables": ApolloClientCast.variables};
-  external castClient: generatedApolloClient => {. "query": [@bs.meth] (queryObj => string)} = "%identity";
+  type mutateObj = {. "mutation": queryString, "variables": ApolloClientCast.variables};
+  external castClient: generatedApolloClient => {.
+    "query": [@bs.meth] (queryObj => string),
+    "mutate": [@bs.meth] (mutateObj => string)
+  } = "%identity";
   [@bs.obj] external getJSQueryConfig : (~query: queryString, ~variables: ApolloClientCast.variables=?, unit) => queryObj = "";
+  [@bs.obj] external getJSMutateConfig : (~mutation: queryString, ~variables: ApolloClientCast.variables=?, unit) => mutateObj = "";
 };
 


### PR DESCRIPTION
This just adds the most basic mutation support. There is more that needs to be done to have more complete mutation support, but this is a first step. I'm new to Reason/OCaml and Apollo so I may be doing something wrong.

I'm using these changes in my project in this context:

```reason

module Client = ReasonApollo.Create({
  let uri = "http://mgmt.ocamurl.dev/graphql";
});

module Query = (ClientConfig: ReasonApollo.ClientConfig) => {

  module CastApolloClient = ApolloClient.Cast({
    type variables = ClientConfig.variables
  });
  let apolloClient = CastApolloClient.castClient(Client.apolloClient);

  external cast : string => {. 
    "data": ClientConfig.responseType, "loading": bool
  } = "%identity";

  type state = 
    | Loading
    | Loaded(ClientConfig.responseType)
    | Failed(string);


  exception SendFailure(Js.Promise.error,
                        ReasonApolloTypes.queryString,
                        option(ClientConfig.variables));

  let send = (typ, ~query, ~variables) => {
    let module P = Js.Promise;

    P.make((~resolve, ~reject) => {
      let requestPromise = switch typ {
      | `Query => {
          let conf = CastApolloClient.getJSQueryConfig(
            ~query, ~variables=?variables, ());
          apolloClient##query(conf) 
        }
      | `Mutation => {
          let conf = CastApolloClient.getJSMutateConfig(
            ~mutation=query, ~variables=?variables, ());
          apolloClient##mutate(conf)
        }
      };
      P.resolve(requestPromise)

      |> P.then_((result) => {
        let typedResult = cast(result)##data;
        [@bs] resolve(typedResult);
        P.resolve()
      })

      |> P.catch((error) => {
        [@bs] reject(SendFailure(error, query, variables));
        P.resolve()
      })

      |> ignore;
      ()
    })
  };

};

type error = {. "code": string, "message": string };
```