### PR TITLE
Add "apollo-client" peerDependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.0.0",
     "apollo-link-http": "^1.0.0",
+    "apollo-client": "^2.0.4",
     "bs-platform": "^2.0.0"
   },
   "keywords": [


### PR DESCRIPTION
In Reason-Apollo, src/ApolloClient.re has a call to "apollo-client" module.

[@bs.module "apollo-client"] [@bs.new] external apolloClient : clientOptions => generatedApolloClient = "ApolloClient";

But "apollo-client" module isn't in packages.json dependencies. Is it on purpose? Should it be added to peerDependency? (Or something else.)

Is it on purpose? Unless I add this package "apollo-client" it is broken for me.