### PR TITLE
Improve bs config and package scripts/deps, define examples folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ node_modules/
 .merlin
 
 lib
+*.bs.js
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
     - node_modules
 install: npm install
 script:
-  - npm run test:ci
+  - npm run build

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,11 +1,27 @@
 {
   "name": "reason-apollo",
   "sources": [
-    "src",
-    "src/graphql-types"
+    {
+      "dir": "src",
+      "public": "all",
+      "subdirs": ["graphql-types"]
+    },
+    {
+      "dir": "examples",
+      "type": "dev"
+    }
   ],
-  "bs-dependencies": [
-    "reason-react"
+  "bs-dependencies": ["reason-react"],
+  "bsc-flags": ["-bs-super-errors"],
+  "reason": {
+    "react-jsx": 2
+  },
+  "refmt": 3,
+  "package-specs": [
+    {
+      "module": "es6",
+      "in-source": true
+    }
   ],
-  "refmt": 3
+  "suffix": ".bs.js"
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,1 @@
+This folder contains working examples of usage of the library.

--- a/package.json
+++ b/package.json
@@ -8,23 +8,24 @@
     "url": "https://github.com/apollographql/reason-apollo"
   },
   "scripts": {
-    "test:ci": "bsb -make-world",
-    "prepare": "npm link bs-platform"
+    "build": "bsb -make-world",
+    "start": "bsb -make-world -w",
+    "clean": "bsb -clean-world",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "apollo-cache-inmemory": "^1.0.0",
-    "apollo-link-http": "^1.0.0",
-    "apollo-client": "^2.0.4",
-    "bs-platform": "^2.0.0"
+    "apollo-cache-inmemory": "^1.1.5",
+    "apollo-link-http": "^1.3.2",
+    "apollo-client": "^2.2.0",
+    "bs-platform": "^2.1.0"
   },
-  "keywords": [
-    "Reason",
-    "Apollo",
-    "React",
-    "GraphQL"
-  ],
+  "keywords": ["Reason", "Apollo", "React", "GraphQL"],
   "author": "Grégoire Van der Auwermeulen <gregoirevandera@gmail.com>",
   "devDependencies": {
+    "apollo-cache-inmemory": "^1.1.5",
+    "apollo-link-http": "^1.3.2",
+    "apollo-client": "^2.2.0",
+    "bs-platform": "^2.1.0",
     "reason-react": "^0.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,73 @@
 # yarn lockfile v1
 
 
+"@types/async@2.0.46":
+  version "2.0.46"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.46.tgz#f13a6c336a6582b95d0c0269e796b709488fd54d"
+
+"@types/zen-observable@0.5.3", "@types/zen-observable@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
+
+apollo-cache-inmemory@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz#74111367fd59caee120197ef663dcb2516971300"
+  dependencies:
+    apollo-cache "^1.1.0"
+    apollo-utilities "^1.0.4"
+    graphql-anywhere "^4.1.1"
+
+apollo-cache@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.0.tgz#281b6a0fb6ca2c5bce69825642f685de92d05f3c"
+  dependencies:
+    apollo-utilities "^1.0.4"
+
+apollo-client@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.2.0.tgz#e22c4ba3a3c01aec6dc916a5dbc0f39c58d277fb"
+  dependencies:
+    "@types/zen-observable" "^0.5.3"
+    apollo-cache "^1.1.0"
+    apollo-link "^1.0.0"
+    apollo-link-dedup "^1.0.0"
+    apollo-utilities "^1.0.4"
+    symbol-observable "^1.0.2"
+    zen-observable "^0.7.0"
+  optionalDependencies:
+    "@types/async" "2.0.46"
+
+apollo-link-dedup@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz#1c213d7ebbe48e74b016fffacd7e6a53dc309e32"
+  dependencies:
+    apollo-link "^1.0.7"
+
+apollo-link-http@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.3.2.tgz#63537ee5ecf9c004efb0317f1222b7dbc6f21559"
+  dependencies:
+    apollo-link "^1.0.7"
+
+apollo-link@^1.0.0, apollo-link@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
+  dependencies:
+    "@types/zen-observable" "0.5.3"
+    apollo-utilities "^1.0.0"
+    zen-observable "^0.6.0"
+
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.4.tgz#560009ea5541b9fdc4ee07ebb1714ee319a76c15"
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-bs-platform@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.0.0.tgz#17ee607fa829f67b8b920438ebca5ec1deab3276"
+bs-platform@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.1.0.tgz#63560ff8f7142c9c0631559df1c35590b9f6d8b2"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -31,6 +91,12 @@ fbjs@^0.8.16:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+graphql-anywhere@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.1.tgz#67924b67b053d1a23bc30d0e4c8db943c1d791a8"
+  dependencies:
+    apollo-utilities "^1.0.4"
 
 iconv-lite@~0.4.13:
   version "0.4.19"
@@ -111,6 +177,10 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
+symbol-observable@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
@@ -118,3 +188,11 @@ ua-parser-js@^0.7.9:
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
+zen-observable@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.6.1.tgz#01dbed3bc8d02cbe9ee1112c83e04c807f647244"
+
+zen-observable@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"


### PR DESCRIPTION
Some small improvements to follow the setup I've seen so far in other "bs" packages.

* use [`in-source` mode](https://bucklescript.github.io/docs/en/interop-with-js-build-systems.html#tips-tricks) to output compiled `*.bs.js` files next to their sources
* use proper `scripts`
* avoid linking of `bs-platform`, instead require it as a dev dep
* added an `example` folder (this will contain **working** `*.re` files with usage examples, instead of hardcode them in the README)