### PR TITLE
Make apollo client configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ node_modules/
 .merlin
 
 lib
+*.bs.js
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
     - node_modules
 install: npm install
 script:
-  - npm run test:ci
+  - npm run build

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,11 +1,27 @@
 {
   "name": "reason-apollo",
   "sources": [
-    "src",
-    "src/graphql-types"
+    {
+      "dir": "src",
+      "public": "all",
+      "subdirs": ["graphql-types"]
+    },
+    {
+      "dir": "examples",
+      "type": "dev"
+    }
   ],
-  "bs-dependencies": [
-    "reason-react"
+  "bs-dependencies": ["reason-react"],
+  "bsc-flags": ["-bs-super-errors"],
+  "reason": {
+    "react-jsx": 2
+  },
+  "refmt": 3,
+  "package-specs": [
+    {
+      "module": "es6",
+      "in-source": true
+    }
   ],
-  "refmt": 3
+  "suffix": ".bs.js"
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,1 @@
+This folder contains working examples of usage of the library.

--- a/examples/create_apollo_client.re
+++ b/examples/create_apollo_client.re
@@ -1,0 +1,90 @@
+open ApolloLinks;
+
+/* Fake some methods, for the sake of the example */
+let getAccessToken = () => "123";
+
+let logout = () => ();
+
+/* Create an HTTP Link */
+module HttpLink =
+  CreateHttpLink(
+    {
+      let uri = "http://localhost:3999";
+    }
+  );
+
+/* Create a Link that puts an Authorization header in context */
+module AuthLink =
+  CreateContextLink(
+    {
+      let contextHandler = () => {
+        let token = getAccessToken();
+        let headers = {
+          "headers": {
+            "authorization": {j|Bearer $token|j}
+          }
+        };
+        asJsObject(headers);
+      };
+    }
+  );
+
+/* Create a Link that handles 401 error responses */
+module ErrorLink =
+  CreateErrorLink(
+    {
+      let errorHandler = errorResponse =>
+        switch errorResponse##networkError {
+        | Some(error) =>
+          if (error##statusCode == 401) {
+            logout();
+          } else {
+            ();
+          }
+        | None => ()
+        };
+    }
+  );
+
+/* Create an InMemoryCache */
+module InMemoryCache =
+  ReasonApollo.CreateInMemoryCache(
+    {
+      type dataObject = {
+        .
+        "__typename": string,
+        "id": string,
+        "key": string
+      };
+      let inMemoryCacheObject =
+        Js_null_undefined.return({
+          "dataIdFromObject": (obj: dataObject) =>
+            if (obj##__typename === "Organization") {
+              obj##key;
+            } else {
+              obj##id;
+            }
+        });
+    }
+  );
+
+/* Alternatively if you want to use the default values of InMemoryCache: */
+/*
+ module InMemoryCache =
+   ReasonApollo.CreateInMemoryCache(
+     {
+       type dataObject;
+       let inMemoryCacheObject = Js_null_undefined.undefined;
+     }
+   );
+ */
+/* Create the ApolloClient */
+module Client =
+  ReasonApollo.CreateClient(
+    {
+      let links = [|AuthLink.link, ErrorLink.link, HttpLink.link|];
+      let cache = InMemoryCache.cache;
+    }
+  );
+
+let apolloClient = Client.apolloClient;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.1.5",
+    "apollo-link": "^1.0.7",
+    "apollo-link-context": "^1.0.3",
+    "apollo-link-error": "^1.0.3",
     "apollo-link-http": "^1.3.2",
     "apollo-client": "^2.2.0",
     "bs-platform": "^2.1.0"
@@ -23,6 +26,9 @@
   "author": "Grégoire Van der Auwermeulen <gregoirevandera@gmail.com>",
   "devDependencies": {
     "apollo-cache-inmemory": "^1.1.5",
+    "apollo-link": "^1.0.7",
+    "apollo-link-context": "^1.0.3",
+    "apollo-link-error": "^1.0.3",
     "apollo-link-http": "^1.3.2",
     "apollo-client": "^2.2.0",
     "bs-platform": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -8,23 +8,24 @@
     "url": "https://github.com/apollographql/reason-apollo"
   },
   "scripts": {
-    "test:ci": "bsb -make-world",
-    "prepare": "npm link bs-platform"
+    "build": "bsb -make-world",
+    "start": "bsb -make-world -w",
+    "clean": "bsb -clean-world",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "apollo-cache-inmemory": "^1.0.0",
-    "apollo-link-http": "^1.0.0",
-    "apollo-client": "^2.0.4",
-    "bs-platform": "^2.0.0"
+    "apollo-cache-inmemory": "^1.1.5",
+    "apollo-link-http": "^1.3.2",
+    "apollo-client": "^2.2.0",
+    "bs-platform": "^2.1.0"
   },
-  "keywords": [
-    "Reason",
-    "Apollo",
-    "React",
-    "GraphQL"
-  ],
+  "keywords": ["Reason", "Apollo", "React", "GraphQL"],
   "author": "Grégoire Van der Auwermeulen <gregoirevandera@gmail.com>",
   "devDependencies": {
+    "apollo-cache-inmemory": "^1.1.5",
+    "apollo-link-http": "^1.3.2",
+    "apollo-client": "^2.2.0",
+    "bs-platform": "^2.1.0",
     "reason-react": "^0.2.4"
   }
 }

--- a/src/ApolloLinks.re
+++ b/src/ApolloLinks.re
@@ -1,0 +1,79 @@
+open ReasonApolloTypes;
+
+/**
+ * A convenience method to cast a generic type to a record object.
+ */
+external asJsObject : 'a => Js.t({..}) = "%identity";
+
+/**
+ * CreateHttpLink
+ * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http
+ */
+module type HttpLinkConfig = {
+  /**
+   * The endpoint where the GraphQL server is running.
+   * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http#options
+   * TODO: support other options
+   */
+  let uri: string;
+};
+
+module CreateHttpLink = (Config: HttpLinkConfig) => {
+  /* Bind the HttpLink class */
+  [@bs.module "apollo-link-http"] [@bs.new]
+  external createHttpLink : ApolloClient.linkOptions => apolloLink =
+    "HttpLink";
+  /* Instanciate a new http link object */
+  let link = createHttpLink({"uri": Config.uri});
+};
+
+/**
+ * CreateContextLink
+ * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-context
+ */
+module type ContextLinkConfig = {
+  /**
+   * Define the callback function to set the new context of a request.
+   * The function returns an object record (use the utility function `asJsObject`)
+   * to cast your custom object to this generic type.
+   * TODO: support passing the arguments of the function.
+   */
+  let contextHandler: unit => Js.t({..});
+};
+
+module CreateContextLink = (Config: ContextLinkConfig) => {
+  /* Bind the setContext method */
+  [@bs.module "apollo-link-context"]
+  external apolloLinkSetContext : (unit => Js.t({..})) => apolloLink =
+    "setContext";
+  /* Instanciate a new context link object */
+  let link = apolloLinkSetContext(Config.contextHandler);
+};
+
+/**
+ * CreateErrorLink
+ * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-error
+ */
+type networkError = {. "statusCode": int};
+
+/* TODO: define missing keys */
+type apolloLinkErrorResponse = {. "networkError": option(networkError)};
+
+module type ErrorLinkConfig = {
+  /**
+   * Define the callback function that gets called in the event of an error.
+   * This function is called with an object containing the keys defined here:
+   * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-error#callback
+   * NOTE: at the moment only `networkError` field is supported
+   */
+  let errorHandler: apolloLinkErrorResponse => unit;
+};
+
+module CreateErrorLink = (Config: ErrorLinkConfig) => {
+  /* Bind the onError method */
+  [@bs.module "apollo-link-error"]
+  external apolloLinkOnError : (apolloLinkErrorResponse => unit) => apolloLink =
+    "onError";
+  /* Instanciate a new error link object */
+  let link = apolloLinkOnError(Config.errorHandler);
+};

--- a/src/ReasonApollo.re
+++ b/src/ReasonApollo.re
@@ -1,13 +1,84 @@
-module type CreationConfig = {let uri: string;};
+open ReasonApolloTypes;
 
-module Create = (CreationConfig: CreationConfig) => {
-  let httpLinkOptions: ApolloClient.linkOptions = {"uri": CreationConfig.uri};
-  let apolloClientOptions: ApolloClient.clientOptions = {
-    "cache": ApolloClient.inMemoryCache(),
-    "link": ApolloClient.httpLink(httpLinkOptions)
-  };
-  let apolloClient = ApolloClient.apolloClient(apolloClientOptions);
+/**
+ * CreateInMemoryCache
+ * https://github.com/apollographql/apollo-client/tree/master/packages/apollo-cache-inmemory
+ */
+module type ApolloInMemoryCacheConfig = {
+  /**
+   * Describe your data object shape. Usually you have following keys:
+   * - "__typename": string
+   * - "id": string
+   */
+  type dataObject;
+  /**
+   * Define the object to pass to the InMemoryCache constructor.
+   * If you don't want to pass any object, simply return `Js_null_undefined.undefined`.
+   */
+  let inMemoryCacheObject:
+    /* TODO: define missing fields */
+    Js.Nullable.t({. "dataIdFromObject": dataObject => string});
+};
 
-  module Query = ReasonApolloQuery.QueryFactory({ let apolloClient = apolloClient;});
-  module Mutation = ReasonApolloMutation.MutationFactory({let apolloClient = apolloClient;});
+module CreateInMemoryCache = (Config: ApolloInMemoryCacheConfig) => {
+  /* Define the type of the object to pas to the InMemoryCache constructor */
+  type inMemoryCacheObject =
+    Js.Nullable.t({. "dataIdFromObject": Config.dataObject => string});
+  /* Bind the InMemoryCache class */
+  [@bs.module "apollo-cache-inmemory"] [@bs.new]
+  external createInMemoryCache : inMemoryCacheObject => apolloCache =
+    "InMemoryCache";
+  /* Instanciate a new cache object */
+  let cache = createInMemoryCache(Config.inMemoryCacheObject);
+};
+
+/**
+ * CreateClient
+ * https://github.com/apollographql/apollo-client
+ */
+module type ApolloClientConfig = {
+  /**
+   * An array of links, each one constructed with one of the available
+   * modules in ApolloLinks
+   */
+  let links: array(apolloLink);
+  /**
+   * A cache object, usually an instance of InMemoryCache
+   */
+  let cache: apolloCache;
+};
+
+module CreateClient = (Config: ApolloClientConfig) => {
+  /* Bind the ApolloClient class */
+  [@bs.module "apollo-client"] [@bs.new]
+  external createApolloClient :
+    clientOptions => ApolloClient.generatedApolloClient =
+    "ApolloClient";
+  /* Bind the method `from`, used to compose links together */
+  [@bs.module "apollo-link"]
+  external createApolloLinkFrom : array(apolloLink) => apolloLink = "from";
+  /*Instanciate a new client object */
+  let apolloClient =
+    createApolloClient({
+      "cache": Config.cache,
+      "link": createApolloLinkFrom(Config.links)
+    });
+  /**
+   * Expose a module to perform "query" operations for the given client
+   */
+  module Query =
+    ReasonApolloQuery.QueryFactory(
+      {
+        let apolloClient = apolloClient;
+      }
+    );
+  /**
+   * Expose a module to perform "mutation" operations for the given client
+   */
+  module Mutation =
+    ReasonApolloMutation.MutationFactory(
+      {
+        let apolloClient = apolloClient;
+      }
+    );
 };

--- a/src/ReasonApolloTypes.re
+++ b/src/ReasonApolloTypes.re
@@ -1,3 +1,30 @@
+/**
+ * An abstract type to describe a query string object.
+ */
 type queryString;
 
+/**
+ * The signature of the `graphql-tag/gql` function that transforms a GraphQL
+ * query string to the standard GraphQL AST.
+ * https://github.com/apollographql/graphql-tag
+ */
 type gql = [@bs] (string => queryString);
+
+/**
+ * An abstract type to describe an Apollo Link object.
+ */
+type apolloLink;
+
+/**
+ * An abstract type to describe an Apollo Cache object.
+ */
+type apolloCache;
+
+/**
+ * Describe the options needed to construct an ApolloClient object.
+ */
+type clientOptions = {
+  .
+  "cache": apolloCache,
+  "link": apolloLink
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,73 @@
 # yarn lockfile v1
 
 
+"@types/async@2.0.46":
+  version "2.0.46"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.46.tgz#f13a6c336a6582b95d0c0269e796b709488fd54d"
+
+"@types/zen-observable@0.5.3", "@types/zen-observable@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
+
+apollo-cache-inmemory@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz#74111367fd59caee120197ef663dcb2516971300"
+  dependencies:
+    apollo-cache "^1.1.0"
+    apollo-utilities "^1.0.4"
+    graphql-anywhere "^4.1.1"
+
+apollo-cache@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.0.tgz#281b6a0fb6ca2c5bce69825642f685de92d05f3c"
+  dependencies:
+    apollo-utilities "^1.0.4"
+
+apollo-client@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.2.0.tgz#e22c4ba3a3c01aec6dc916a5dbc0f39c58d277fb"
+  dependencies:
+    "@types/zen-observable" "^0.5.3"
+    apollo-cache "^1.1.0"
+    apollo-link "^1.0.0"
+    apollo-link-dedup "^1.0.0"
+    apollo-utilities "^1.0.4"
+    symbol-observable "^1.0.2"
+    zen-observable "^0.7.0"
+  optionalDependencies:
+    "@types/async" "2.0.46"
+
+apollo-link-dedup@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz#1c213d7ebbe48e74b016fffacd7e6a53dc309e32"
+  dependencies:
+    apollo-link "^1.0.7"
+
+apollo-link-http@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.3.2.tgz#63537ee5ecf9c004efb0317f1222b7dbc6f21559"
+  dependencies:
+    apollo-link "^1.0.7"
+
+apollo-link@^1.0.0, apollo-link@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
+  dependencies:
+    "@types/zen-observable" "0.5.3"
+    apollo-utilities "^1.0.0"
+    zen-observable "^0.6.0"
+
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.4.tgz#560009ea5541b9fdc4ee07ebb1714ee319a76c15"
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-bs-platform@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.0.0.tgz#17ee607fa829f67b8b920438ebca5ec1deab3276"
+bs-platform@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.1.0.tgz#63560ff8f7142c9c0631559df1c35590b9f6d8b2"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -31,6 +91,12 @@ fbjs@^0.8.16:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+graphql-anywhere@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.1.tgz#67924b67b053d1a23bc30d0e4c8db943c1d791a8"
+  dependencies:
+    apollo-utilities "^1.0.4"
 
 iconv-lite@~0.4.13:
   version "0.4.19"
@@ -111,6 +177,10 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
+symbol-observable@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
@@ -118,3 +188,11 @@ ua-parser-js@^0.7.9:
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
+zen-observable@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.6.1.tgz#01dbed3bc8d02cbe9ee1112c83e04c807f647244"
+
+zen-observable@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,11 +38,23 @@ apollo-client@^2.2.0:
   optionalDependencies:
     "@types/async" "2.0.46"
 
+apollo-link-context@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.3.tgz#9b823e26780a39655a35347f0b0e88b83acdeabe"
+  dependencies:
+    apollo-link "^1.0.6"
+
 apollo-link-dedup@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz#1c213d7ebbe48e74b016fffacd7e6a53dc309e32"
   dependencies:
     apollo-link "^1.0.7"
+
+apollo-link-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.0.3.tgz#2c679d2e6a2df09a9ae3f70d23c64af922a801a2"
+  dependencies:
+    apollo-link "^1.0.6"
 
 apollo-link-http@^1.3.2:
   version "1.3.2"
@@ -50,7 +62,7 @@ apollo-link-http@^1.3.2:
   dependencies:
     apollo-link "^1.0.7"
 
-apollo-link@^1.0.0, apollo-link@^1.0.7:
+apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
   dependencies:


### PR DESCRIPTION
This PR is meant to address the requests of #13.

<h3 align="center"> ⚠️This PR is branched off #14 (which hasn't been merged yet). To see only the changes related to this PR look at the commits other then the first. ⚠️ </h3>

### Summary
The main focus of this PR is to make the options to pass to the `client` constructor configurable. This obviously refers to:
* `link`
* `cache`

### Description
Following the current approach of using [functors](https://reasonml.github.io/docs/en/module.html#module-functions-functors) to configure new modules given their signature, I defined a bunch of such modules to build **links** and **cache** objects.

The final result is something like this:

```reason
/* Create the ApolloClient */
module Client =
  ReasonApollo.CreateClient(
    {
      let links = [|AuthLink.link, ErrorLink.link, HttpLink.link|];
      let cache = InMemoryCache.cache;
    }
  );

let apolloClient = Client.apolloClient;
```

The constructors for **link** modules are in the `ApolloLinks.re` file.

* `CreateHttpLink`: to build a `apollo-link-http` link object
* `CreateContextLink`: to build a `apollo-link-context` link object
* `CreateErrorLink`: to build a `apollo-link-error` link object

Similarly, there is a `CreateInMemoryCache` in the `ReasonApollo.re` file.

### Examples
To make sure the code compiles correctly, I created a `create_apollo_client.re` example file that focuses on setup links and cache for creating an Apollo Client.

In theory, it would be good have different examples also for configuring the queries/mutations for a React component instead of hardcoding it in the README (as mentioned in #14).

### Notes
I hope the approach is fine for you guys. I'm happy to receive feedback and suggestions on improving the types and the setup.
Also I haven't covered all the possible options available for each of the links/cache/client, this can be done separately.

Thanks 🙏
  