### PR TITLE
Add bindings for fragment matcher

### DIFF
--- a/src/ApolloInMemoryCache.re
+++ b/src/ApolloInMemoryCache.re
@@ -19,12 +19,32 @@ type inMemoryCacheRestoreData = Js.Nullable.t(restoreData);
 /* Bind the InMemoryCache class */
 [@bs.module "apollo-cache-inmemory"]
 [@bs.new]
-external apolloInMemoryCache : 'a => apolloCache =
-  "InMemoryCache";
+external apolloInMemoryCache : 'a => apolloCache = "InMemoryCache";
 
 /* Bind the restore method */
-[@bs.send.pipe : 't] external restore : inMemoryCacheRestoreData => apolloCache = "restore";
+[@bs.send.pipe : 't]
+external restore : inMemoryCacheRestoreData => apolloCache = "restore";
+
+/* Fragment matcher */
+type fragmentMatcher;
+
+[@bs.module "apollo-cache-inmemory"] [@bs.new]
+external introspectionFragmentMatcher : 'a => fragmentMatcher =
+  "IntrospectionFragmentMatcher";
+
+let createIntrospectionFragmentMatcher = (~data) =>
+  introspectionFragmentMatcher({"introspectionQueryResultData": data});
 
 /* Instantiate a new cache object */
-let createInMemoryCache = (~dataIdFromObject=?, ()) =>
-  apolloInMemoryCache({"dataIdFromObject": Js.Nullable.from_opt(dataIdFromObject)});
+let createInMemoryCache = (~dataIdFromObject=?, ~fragmentMatcher=?, ()) =>
+  switch fragmentMatcher {
+  | Some(fragmentMatcher) =>
+    apolloInMemoryCache({
+      "dataIdFromObject": Js.Nullable.from_opt(dataIdFromObject),
+      "fragmentMatcher": Js.Nullable.return(fragmentMatcher)
+    })
+  | None =>
+    apolloInMemoryCache({
+      "dataIdFromObject": Js.Nullable.from_opt(dataIdFromObject)
+    })
+  };


### PR DESCRIPTION
Add bindings for the `IntrospectionFragmentMatcher` class and a `fragmentMatcher` parameter to `createInMemoryCache`.

Sadly passing `undefined` to `InMemoryCache` crashes, probably because it checks for the prop existence in the config.  This is why I had to switch on `fragmentMatcher` and pass the config with only the right fields.

Tested that it works with and without the `fragmentMatcher` param.