### PR TITLE
[WIP] Rewrite ReasonApolloQuery to use watchQuery

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -1,10 +1,49 @@
 open ReasonApolloTypes;
 
-type queryObj = {. "query": ReasonApolloTypes.queryString, "variables": Js.Json.t };
-type mutationObj = {. "mutation": ReasonApolloTypes.queryString, "variables": Js.Json.t};
+type queryObj = {
+  .
+  "query": ReasonApolloTypes.queryString,
+  "variables": Js.Json.t
+};
 
-type generatedApolloClient = {. 
-  "query": [@bs.meth] (queryObj => string),
+type queryObservableObj = {
+  .
+  "query": ReasonApolloTypes.queryString,
+  "variables": Js.Json.t
+};
+
+type result = {
+  .
+  "data": Js.nullable(Js.Json.t),
+  "error": Js.nullable(string),
+  "loading": Js.boolean
+};
+
+type subscription = {. [@bs.meth] "unsubscribe": unit => unit};
+
+type watchQueryObservable = {
+  .
+  [@bs.meth] "currentResult":  (unit => result),
+  [@bs.meth] "result": unit => Js.Promise.t(result),
+  [@bs.meth]
+  "subscribe": {
+    .
+    "next": result => unit,
+    "error": Js.Exn.t => unit
+  } => subscription,
+  [@bs.meth] "getLastError": [@bs.return nullable] (unit => option(Js.Exn.t))
+};
+
+type mutationObj = {
+  .
+  "mutation": ReasonApolloTypes.queryString,
+  "variables": Js.Json.t
+};
+
+type generatedApolloClient = {
+  .
+  "query": [@bs.meth] (queryObj => Js.Promise.t(result)),
+  "watchQuery": [@bs.meth] (queryObservableObj => watchQueryObservable),
   "mutate": [@bs.meth] (mutationObj => string)
 };
 


### PR DESCRIPTION
Based on the JS implementation https://github.com/apollographql/react-apollo/blob/master/src/Query.tsx. This fixes setting initial state (render data if in cache instead of always loading) and should work with subscriptions (haven't tested that), will also make adding features like polling easy.

Tested that it works with a simple query and when changing variables.

TODO:
- Figure out how to get rid of the `Warning: An update (setState, replaceState, or forceUpdate) was scheduled from inside an update function. Update functions should be pure, with zero side-effects. Consider using componentDidUpdate or a callback.` warning.