### PR TITLE
Remove opam install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Easily use the Apollo Client 2 with Reason
 yarn add reason-apollo
 
 # Add graphql_ppx
-opam install graphql_ppx
 yarn add --dev graphql_ppx
 ```
 


### PR DESCRIPTION
Not necessary with graphql_ppx v 0.2.0 which exports binary