### PR TITLE
Update graphql_ppx to v 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "apollo-link-http": "^1.3.2",
     "bs-platform": "^2.1.0",
     "graphql-tag": "^2.6.1",
-    "graphql_ppx": "^0.0.1",
+    "graphql_ppx": "^0.2.0",
     "reason-react": "^0.3.1"
   },
   "dependencies": {


### PR DESCRIPTION
Line 40. Updating avoid have to install opam to get this to run. Can now compile with just npm i, yarn.