### PR TITLE
Added types to QueryFactory and MutationFactory functors

### DIFF
--- a/examples/swapi/package.json
+++ b/examples/swapi/package.json
@@ -25,7 +25,7 @@
     "graphql-tag": "^2.7.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "reason-apollo": "^0.6.14",
+    "reason-apollo": "file:../../",
     "reason-react": ">=0.3.0"
   },
   "devDependencies": {

--- a/examples/swapi/src/Characters.re
+++ b/examples/swapi/src/Characters.re
@@ -1,0 +1,58 @@
+let ste = ReasonReact.stringToElement;
+
+module CharacterQuery = [%graphql
+  {|
+  query characters($first: Int) {
+    allPeople(first: $first) {
+      people {
+        name
+      }
+    }
+  }
+|}
+];
+
+let parseCharacters =
+  fun
+  | Some(allCharacters) =>
+    switch allCharacters##people {
+    | Some(characters) =>
+      Js.Array.map(
+        character =>
+          switch character {
+          | Some(c) => switch (c##name) {
+            | Some(name) => name
+            | None => ""
+            }
+          | None => ""
+          },
+        characters
+      )
+    | None => [||]
+    }
+  | None => [||];
+
+let component = ReasonReact.statelessComponent("Characters");
+
+let make = (~queryClient, _children) => {
+  ...component,
+  render: _self => {
+    let characterQuery = CharacterQuery.make(~first=10, ());
+    module Query = (val (queryClient: (module ReasonApolloQuery.Query)));
+    <Query query=characterQuery>
+      ...(
+           (response, parse) =>
+             switch response {
+             | Loading => <div> (ste("Loading")) </div>
+             | Failed(error) => <div> (ste(error)) </div>
+             | Loaded(result) =>
+               let allCharacters = parse(result)##allPeople;
+               let parsedFilms = parseCharacters(allCharacters);
+               <ul>
+                 (ReasonReact.arrayToElement(Array.map(film => <li> (ste(film)) </li>, parsedFilms)))
+               </ul>;
+             }
+         )
+    </Query>;
+  }
+};

--- a/examples/swapi/src/Page.re
+++ b/examples/swapi/src/Page.re
@@ -1,7 +1,15 @@
+let ste = ReasonReact.stringToElement;
+
 let component = ReasonReact.statelessComponent("Page");
 
 let make = _children => {
   ...component,
   render: _self =>
-    <div> <h1> (ReasonReact.stringToElement("Star Wars")) </h1> <Feed /> </div>
+    <div>
+      <h1> (ste("Star Wars")) </h1>
+      <h2> (ste("Movies")) </h2>
+      <Feed />
+      <h2> (ste("Characters")) </h2>
+      <Characters queryClient=(module Client.Instance.Query) />
+    </div>
 };

--- a/examples/swapi/yarn.lock
+++ b/examples/swapi/yarn.lock
@@ -1837,9 +1837,8 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-reason-apollo@^0.6.14:
-  version "0.6.14"
-  resolved "https://registry.yarnpkg.com/reason-apollo/-/reason-apollo-0.6.14.tgz#a27f2a4784954e6c44cca16b89d66cce0dcdbc2b"
+"reason-apollo@file:../..":
+  version "0.6.17"
   dependencies:
     fbjs "^0.8.16"
 

--- a/src/ReasonApollo.re
+++ b/src/ReasonApollo.re
@@ -21,7 +21,15 @@ let createApolloClient =
 
 module type ApolloClientConfig = {let apolloClient: ApolloClient.generatedApolloClient;};
 
-module CreateClient = (Config: ApolloClientConfig) => {
+
+module type Client = {
+  let apolloClient: ApolloClient.generatedApolloClient;
+
+  module Query: ReasonApolloQuery.Query;
+  module Mutation: ReasonApolloMutation.Mutation;
+};
+
+module CreateClient = (Config: ApolloClientConfig) : Client => {
   let apolloClient = Config.apolloClient;
 
   /*


### PR DESCRIPTION
Added types to QueryFactory and MutationFactory. This allows for the created query/mutation to be used as first-class modules within an application.

I added an example to the swapi example app using the Query module as a parameter to the react component.