### PR TITLE
Support passing `context`

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -1,9 +1,20 @@
 open ReasonApolloTypes;
 
-type queryObj = {. "query": ReasonApolloTypes.queryString, "variables": Js.Json.t };
-type mutationObj = {. "mutation": ReasonApolloTypes.queryString, "variables": Js.Json.t};
+type queryObj = {
+  .
+  "query": ReasonApolloTypes.queryString,
+  "variables": Js.Json.t,
+  "context": Js.Nullable.t(Js.Json.t)
+};
 
-type generatedApolloClient = {. 
+type mutationObj = {
+  .
+  "mutation": ReasonApolloTypes.queryString,
+  "variables": Js.Json.t
+};
+
+type generatedApolloClient = {
+  .
   "query": [@bs.meth] (queryObj => string),
   "mutate": [@bs.meth] (mutationObj => string)
 };


### PR DESCRIPTION
This PR adds support for passing `context` of type `Js.Json.t` as a prop of `Query` component. After debating the possible approaches, we settled that this makes the most sense since it doesn't require users to define a context type. It is also quite pleasant to work with as one can probably tell from the below `bs-json` snippet.

I have another PR in works which allows for side effects after making mutation (another issue opened up here).

Simple use case:
```ml
let query = AuthQuery.make();
let context =
   Json.Encode.(
      object_([
        ("headers", object_([("Authorization", string("Bearer " ++ t))]))
      ])
   );
<Query query context>
</Query>
```

Fixes #51 