### PR TITLE
Allow passing client into Query and Mutation components

### DIFF
--- a/src/ReasonApollo.re
+++ b/src/ReasonApollo.re
@@ -23,22 +23,20 @@ module type ApolloClientConfig = {let apolloClient: ApolloClient.generatedApollo
 
 module CreateClient = (Config: ApolloClientConfig) => {
   let apolloClient = Config.apolloClient;
-
   /*
-  * Expose a module to perform "query" operations for the given client
-  */
+   * Expose a module to perform "query" operations for the given client
+   */
   module Query =
-    ReasonApolloQuery.QueryFactory(
+    ReasonApolloFactories.QueryFactory(
       {
         let apolloClient = apolloClient;
       }
     );
-    
   /*
-  * Expose a module to perform "mutation" operations for the given client
-  */
+   * Expose a module to perform "mutation" operations for the given client
+   */
   module Mutation =
-    ReasonApolloMutation.MutationFactory(
+    ReasonApolloFactories.MutationFactory(
       {
         let apolloClient = apolloClient;
       }

--- a/src/graphql-types/ReasonApolloFactories.re
+++ b/src/graphql-types/ReasonApolloFactories.re
@@ -1,0 +1,19 @@
+module type InternalConfig = {let apolloClient: ApolloClient.generatedApolloClient;};
+
+module QueryFactory = (InternalConfig: InternalConfig) => {
+  let component = ReasonReact.statelessComponent("Query");
+  let make = (~query, children) => {
+    ...component,
+    render: (_self) =>
+      <ReasonApolloQuery query client=InternalConfig.apolloClient> ...children </ReasonApolloQuery>
+  };
+};
+
+module MutationFactory = (InternalConfig: InternalConfig) => {
+  let component = ReasonReact.statelessComponent("Mutation");
+  let make = (children) => {
+    ...component,
+    render: (_self) =>
+      <ReasonApolloMutation client=InternalConfig.apolloClient> ...children </ReasonApolloMutation>
+  };
+};

--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -1,58 +1,53 @@
-module type InternalConfig = {let apolloClient: ApolloClient.generatedApolloClient;};
+external cast : string => {. "data": Js.Json.t, "loading": bool} = "%identity";
 
-module MutationFactory = (InternalConfig:InternalConfig) => {
-    external cast : string => {. "data": Js.Json.t, "loading": bool} = "%identity";
-    [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
-    
-    type state =
-      | NotCalled
-      | Loading
-      | Loaded(Js.Json.t)
-      | Failed(Js.Promise.error);
+[@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
 
-    type action =
-      | Result(string)
-      | Error(Js.Promise.error);
+type state =
+  | NotCalled
+  | Loading
+  | Loaded(Js.Json.t)
+  | Failed(Js.Promise.error);
 
-    let sendMutation = (~mutation, ~reduce) => {
-      let _ =
-      Js.Promise.(
-        resolve(InternalConfig.apolloClient##mutate({
-          "mutation": [@bs] gql(mutation##query),
-          "variables": mutation##variables
-        }))
-        |> then_(
-             (value) => {
-               reduce(() => Result(value), ());
-               resolve()
-             }
-           )
-        |> catch(
-             (error) => {
-              reduce(() => Error(error), ());
-              resolve()
-             }
-           )
-      );
-    };
+type action =
+  | Result(string)
+  | Error(Js.Promise.error);
 
-    let component = ReasonReact.reducerComponent("ReasonApollo");
-    let make = (children) => {
-      ...component,
-      initialState: () => NotCalled,
-      reducer: (action, _state) =>
-        switch action {
-          | Result(result) => {
-            let typedResult = cast(result)##data;
-            ReasonReact.Update(Loaded(typedResult))
-          }
-          | Error(error) => ReasonReact.Update(Failed(error))
-        },
-      render: ({reduce, state}) => {
-        let mutate = (mutationFactory) => {
-          sendMutation(~mutation=mutationFactory, ~reduce);
-        };
-        children(mutate, state);
-      }
-    };
-  };
+let sendMutation = (~client, ~mutation, ~reduce) => {
+  let _ =
+    Js.Promise.(
+      resolve(
+        client##mutate({"mutation": [@bs] gql(mutation##query), "variables": mutation##variables})
+      )
+      |> then_(
+           (value) => {
+             reduce(() => Result(value), ());
+             resolve()
+           }
+         )
+      |> catch(
+           (error) => {
+             reduce(() => Error(error), ());
+             resolve()
+           }
+         )
+    );
+  ()
+};
+
+let component = ReasonReact.reducerComponent("ReasonApollo");
+
+let make = (~client, children) => {
+  ...component,
+  initialState: () => NotCalled,
+  reducer: (action, _state) =>
+    switch action {
+    | Result(result) =>
+      let typedResult = cast(result)##data;
+      ReasonReact.Update(Loaded(typedResult))
+    | Error(error) => ReasonReact.Update(Failed(error))
+    },
+  render: ({reduce, state}) => {
+    let mutate = (mutationFactory) => sendMutation(~client, ~mutation=mutationFactory, ~reduce);
+    children(mutate, state)
+  }
+};

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -1,84 +1,67 @@
-module type InternalConfig = {let apolloClient: ApolloClient.generatedApolloClient;};
+external castResponse : string => {. "data": Js.Json.t} = "%identity";
 
-module QueryFactory = (InternalConfig:InternalConfig) => {
-    external castResponse : string => {. "data": Js.Json.t } = "%identity";            
-    external asJsObject : 'a => Js.t({..}) = "%identity";
+external asJsObject : 'a => Js.t({..}) = "%identity";
 
-    [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
-    [@bs.module] external shallowEqual : (Js.t({..}), Js.t({..})) => bool = "fbjs/lib/shallowEqual";
+[@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
 
-    
-    type response =
-      | Loading
-      | Loaded(Js.Json.t)
-      | Failed(string);
+[@bs.module] external shallowEqual : (Js.t({..}), Js.t({..})) => bool = "fbjs/lib/shallowEqual";
 
-    type state = { 
-      response: response, 
-      variables: Js.Json.t
-    };
+type response =
+  | Loading
+  | Loaded(Js.Json.t)
+  | Failed(string);
 
-    type action =
-      | Result(string)
-      | Error(string);
+type state = {
+  response,
+  variables: Js.Json.t
+};
 
-    let sendQuery = (~query, ~reduce) => {
-      let _ =
-      Js.Promise.(
-        resolve(InternalConfig.apolloClient##query({
-          "query": [@bs] gql(query##query),
-          "variables": query##variables
-        }))
-        |> then_(
-             (value) => {
-               reduce(() => Result(value), ());
-               resolve()
-             }
-           )
-        |> catch(
-             (_value) => {
-               reduce(() => Error("an error happened"), ());
-               resolve()
-             }
-           )
-      );
-    };
+type action =
+  | Result(string)
+  | Error(string);
 
-    let component = ReasonReact.reducerComponent("ReasonApollo");
-    let make = (~query as q, children) => {
-      ...component,
-      initialState: () => {
-        response: Loading,
-        variables: q##variables
-      },
-      reducer: (action, state) =>
-        switch action {
-          | Result(result) => {
-            let typedResult = castResponse(result)##data;
-            ReasonReact.Update({
-              ...state,
-              response: Loaded(typedResult)
-            })
-          }
-          | Error(error) => ReasonReact.Update({
-            ...state,
-            response: Failed(error)
-          })
-        },
-      willReceiveProps: ({state, reduce}) => {
-        if(!shallowEqual(asJsObject(q##variables), asJsObject(state.variables))) {
-          sendQuery(~query=q, ~reduce);
-          state;
-        } else {
-          state;
-        }
-      },
-      didMount: ({reduce}) => {
-        sendQuery(~query=q, ~reduce);
-        ReasonReact.NoUpdate;
-      },
-      render: ({state}) => {
-        children(state.response, q##parse);
-      }
-    };
-  };
+let sendQuery = (~client, ~query, ~reduce) => {
+  let _ =
+    Js.Promise.(
+      resolve(client##query({"query": [@bs] gql(query##query), "variables": query##variables}))
+      |> then_(
+           (value) => {
+             reduce(() => Result(value), ());
+             resolve()
+           }
+         )
+      |> catch(
+           (_value) => {
+             reduce(() => Error("an error happened"), ());
+             resolve()
+           }
+         )
+    );
+  ()
+};
+
+let component = ReasonReact.reducerComponent("ReasonApollo");
+
+let make = (~client, ~query as q, children) => {
+  ...component,
+  initialState: () => {response: Loading, variables: q##variables},
+  reducer: (action, state) =>
+    switch action {
+    | Result(result) =>
+      let typedResult = castResponse(result)##data;
+      ReasonReact.Update({...state, response: Loaded(typedResult)})
+    | Error(error) => ReasonReact.Update({...state, response: Failed(error)})
+    },
+  willReceiveProps: ({state, reduce}) =>
+    if (! shallowEqual(asJsObject(q##variables), asJsObject(state.variables))) {
+      sendQuery(~client, ~query=q, ~reduce);
+      state
+    } else {
+      state
+    },
+  didMount: ({reduce}) => {
+    sendQuery(~client, ~query=q, ~reduce);
+    ReasonReact.NoUpdate
+  },
+  render: ({state}) => children(state.response, q##parse)
+};


### PR DESCRIPTION
In my particular use case I need to wait for some promises to be resolved until I can create the Apollo Client. The use of functors for the Query and Mutation modules make this impossible unless using first-class modules (as in #47).
The downside of the first-class module approach is the required packaging and unpacking of the first-class modules which in my opinion is too verbose.

Instead, this PR adds the ability to directly use `<ReasonApolloQuery client query> ... </ReasonApolloQuery>` by passing in the Apollo Client into `ReasonApolloQuery` and `ReasonApolloMutation`.

Note that this is non-breaking. You can still use the `CreateClient` functor as before.