### PR TITLE
Correct reasonml type for ~fragmentMatcher

### DIFF
--- a/src/ApolloInMemoryCache.re
+++ b/src/ApolloInMemoryCache.re
@@ -40,7 +40,7 @@ let createIntrospectionFragmentMatcher = (~data) =>
 makeApolloInMemoryCacheParams : 
 (
   ~dataIdFromObject: (Js.t({..}) => string)=?, 
-  ~fragmentMatcher: (Js.t({..}) => string)=?
+  ~fragmentMatcher: fragmentMatcher=?
 ) => _ = "";
 
 let createInMemoryCache = (~dataIdFromObject=?, ~fragmentMatcher=?, ()) => {


### PR DESCRIPTION
## Issue

When using the fragment matcher, there is an error with the type

```
 We've found a bug for you!
  ./src/Client.re 20:6-20

  18 ┆ createInMemoryCache(
  19 ┆   ~dataIdFromObject=(obj: dataObject) => obj##id,
  20 ┆   ~fragmentMatcher,
  21 ┆   (),
  22 ┆ );

  This has type:
    ApolloInMemoryCache.fragmentMatcher
  But somewhere wanted:
    {.. } => string

ninja: build stopped: subcommand failed.
>>>> Finish compiling(exit: 1)****
```

## Provided fix

Changes the type to `fragmentMatcher`