### PR TITLE
Fix response type for apolloLinkErrorResponse

### DIFF
--- a/src/ReasonApolloTypes.re
+++ b/src/ReasonApolloTypes.re
@@ -23,4 +23,4 @@ type apolloCache;
 type networkError = {. "statusCode": int};
 
 /* TODO: define missing keys */
-type apolloLinkErrorResponse = {. "networkError": option(networkError)};
+type apolloLinkErrorResponse = {. "networkError": networkError};


### PR DESCRIPTION
I believe there is an error in the typing of apolloLinkErrorResponse. I believe networkError is always present - or perhaps it is a `Js.Nullable`?

Anyway, with an error handler like:

```reason
let errorHandler = errorResponse => {
  switch (errorResponse##networkError) {
  | Some(networkError) =>
    if (networkError##statusCode == 401) {
      logOut();
    } else {
      ();
    }
    | None => ()
  }
};
```

Reason compiles this code but then I get a runtime error: `TypeError: Cannot read property 'statusCode' of undefined` referencing the compiled javascript:

```reason
function errorHandler(errorResponse) {
   var match = errorResponse.networkError;
   if (match && match[0].statusCode === 401) {
     return logOut(/* Some */[/* true */1], /* () */0);
   } else {
```

It is trying to access `match[0]` when the error object is actually `match`.

If you know there are some cases where it won't be there, I can change the PR to support a nullable.

Thanks!