### PR TITLE
fix(graphql-types): graphql-tag binding for default export

### DIFF
--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -2,7 +2,7 @@ open ReasonApolloTypes;
 
 module MutationFactory = (Config:Config) => {
     external cast : string => {. "data": Js.Json.t, "loading": bool} = "%identity";
-    [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
+    [@bs.module "graphql-tag"] external gql : ReasonApolloTypes.gql = "default";
     [@bs.module "react-apollo"] external mutationComponent: ReasonReact.reactClass = "Mutation";
 
     let graphqlMutationAST = [@bs] gql(Config.query);

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -1,7 +1,7 @@
 open ReasonApolloTypes;
 
 module Get = (Config:ReasonApolloTypes.Config) => {    
-    [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
+    [@bs.module "graphql-tag"] external gql : ReasonApolloTypes.gql = "default";
     [@bs.module "react-apollo"] external queryComponent : ReasonReact.reactClass = "Query";
     
     type response =


### PR DESCRIPTION
Labels:
- [x] bug

#### Description
Fix bindings for the `default` export of `graphql-tag`

<img width="797" alt="screen shot 2018-05-03 at 22 04 11" src="https://user-images.githubusercontent.com/1110551/39600137-2d59d56a-4f1e-11e8-808f-40e0a140cd19.png">

Instead it should be

```js
var graphqlMutationAST = GraphqlTag.default(Config[/* query */0]);
```


