### PR TITLE
fix(apollo-error): option -> Js.Nullable

### DIFF
--- a/src/ReasonApolloTypes.re
+++ b/src/ReasonApolloTypes.re
@@ -23,7 +23,7 @@ type apolloCache;
 type networkError = {. "statusCode": int};
 
 /* TODO: define missing keys */
-type apolloLinkErrorResponse = {. "networkError": option(networkError)};
+type apolloLinkErrorResponse = {. "networkError": Js.Nullable.t(networkError)};
 
 module type Config = {let query: string; type t; let parse: Js.Json.t => t;};
 


### PR DESCRIPTION
**Pull Request Labels**

- [x] bug
- [x] blocking

Fixes #63 

This now works as expected.

```reason
/* before */
switch (errorResponse##networkError)

/* after */
switch (Js.Nullable.toOption(errorResponse##networkError))
```

Output

```js
var errorLink = ApolloLinks.createErrorLink((function (errorResponse) {
        var match = errorResponse.networkError;
        if (!(match == null) && match.statusCode === 401) {
          Auth.default.logout();
          return /* () */0;
        } else {
          return /* () */0;
        }
      }));
```