### PR TITLE
Fix typo in package.json get-schema

### DIFF
--- a/examples/swapi/package.json
+++ b/examples/swapi/package.json
@@ -7,7 +7,7 @@
     "clean": "bsb -clean-world",
     "webpack": "webpack-dev-server",
     "format": "refmt",
-    "get-schema": "yarn send-introspection-query https://api.graph.cool/simple/v1/cjdgba1jw4ggk0185ig4bhpsn""
+    "get-schema": "yarn send-introspection-query https://api.graph.cool/simple/v1/cjdgba1jw4ggk0185ig4bhpsn"
   },
   "keywords": ["BuckleScript"],
   "author": "",


### PR DESCRIPTION
I tried running the examples for myself, there's an additional `"` which should be removed.



**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
