### PR TITLE
Js.Booleans are just booleans

### DIFF
--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -100,13 +100,11 @@ module Get = (Config: ReasonApolloTypes.Config) => {
             "pollInterval": pollInterval |> fromOption,
             "notifyOnNetworkStatusChange":
               notifyOnNetworkStatusChange
-              |> Js.Option.map((. b) => Js.Boolean.to_js_boolean(b))
               |> fromOption,
             "fetchPolicy": fetchPolicy |> fromOption,
             "errorPolicy": errorPolicy |> fromOption,
             "ssr":
               ssr
-              |> Js.Option.map((. b) => Js.Boolean.to_js_boolean(b))
               |> fromOption,
             "displayName": displayName |> fromOption,
             "delay": delay |> fromOption,


### PR DESCRIPTION
They doesn't need to be mapped any more. This will be broken with the next release of bs-platform.
This seems to be a subset of #94 

