### PR TITLE
Correct the error case in README Query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ let instance = ReasonApollo.createApolloClient(
       ...(({result}) => {
         switch result {
            | Loading => <div> (ReasonReact.string("Loading")) </div>
-           | Error(error) => <div> (ReasonReact.string(error)) </div>
+           | Error(error) => <div> (ReasonReact.string(error##message)) </div>
            | Data(response) => <div> (ReasonReact.string(response##pokemon##name)) </div>
         }
       })


### PR DESCRIPTION
Make the GetPokemonQuery compile per the `apolloError` type def
https://github.com/apollographql/reason-apollo/blob/master/src/ReasonApolloTypes.re#L38



**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
