### PR TITLE
Added ReadFragment module and Function

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -55,7 +55,7 @@ module ReadFragment(Config : ReasonApolloTypes.Config) = {
     "fragment": ReasonApolloTypes.queryString,
   };
 
-  [@bs.send] external readFragment : (ApolloClient.generatedApolloClient, readFragmentObj) => Js.Json.t = "";
+  [@bs.send] external readFragment : (generatedApolloClient, readFragmentObj) => Js.Json.t = "";
 
   let readFragment = (client, id : string) =>
     readFragment(client, {"id": id, "fragment": gql(. Config.query)});

--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -45,3 +45,18 @@ external apolloClientObjectParam :
   ) =>
   _ =
   "";
+
+module ReadFragment(Config : ReasonApolloTypes.Config) = {
+  [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
+
+  type readFragmentObj = {
+    .
+    "id": string,
+    "fragment": ReasonApolloTypes.queryString,
+  };
+
+  [@bs.send] external readFragment : (ApolloClient.generatedApolloClient, readFragmentObj) => Js.Json.t = "";
+
+  let readFragment = (client, id : string) =>
+    readFragment(client, {"id": id, "fragment": gql(. Config.query)});
+};


### PR DESCRIPTION
I am a big fan of using the ReadFragment pattern in Apollo.  So I thought It would be useful to port some of the ReadFragment functionality to Reason Apollo.  

The usage looks like this:

```
module Fragment = [%graphql {|
  fragment userFields on User {
    id
    email
  }
|}];

module UserFragment = ApolloClient.ReadFragment(User_Model.Fragment.UserFields);
let userId = "123";
let res = UserFragment.readFragment(Client.instance, "User:" ++ userId);
```


**Pull Request Labels**

- [x] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
