### PR TITLE
Add types for GraphQL responses

### DIFF
--- a/src/ReasonApolloTypes.re
+++ b/src/ReasonApolloTypes.re
@@ -70,6 +70,22 @@ type apolloOptions = {
     "variables": Js.Json.t,
 };
 
+type queryResponse('a) =
+  | Loading
+  | Error(apolloError)
+  | Data('a);
+
+type mutationResponse('a) =
+  | Loading
+  | Error(apolloError)
+  | Data('a)
+  | NotCalled;
+
+type subscriptionResponse('a) =
+  | Loading
+  | Error(apolloError)
+  | Data('a);
+
 /* 
  apollo link ws
  */

--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -13,11 +13,7 @@ module MutationFactory = (Config: Config) => {
   [@bs.module "react-apollo"]
   external mutationComponent : ReasonReact.reactClass = "Mutation";
   let graphqlMutationAST = gql(. Config.query);
-  type response =
-    | Loading
-    | Error(apolloError)
-    | Data(Config.t)
-    | NotCalled;
+  type response = mutationResponse(Config.t);
   type renderPropObj = {
     result: response,
     data: option(Config.t),

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -4,10 +4,7 @@ module Get = (Config: ReasonApolloTypes.Config) => {
   [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
   [@bs.module "react-apollo"]
   external queryComponent : ReasonReact.reactClass = "Query";
-  type response =
-    | Loading
-    | Error(apolloError)
-    | Data(Config.t);
+  type response = queryResponse(Config.t);
 
   [@bs.deriving abstract]
   type updateQueryOptions = {

--- a/src/graphql-types/ReasonApolloSubscription.re
+++ b/src/graphql-types/ReasonApolloSubscription.re
@@ -6,10 +6,7 @@ module Get = (Config: ReasonApolloTypes.Config) => {
 
   let graphQLSubscriptionAST = gql(. Config.query);
   
-  type response = 
-    | Loading
-    | Error(apolloError)
-    | Data(Config.t);
+  type response = subscriptionResponse(Config.t);
 
   type renderPropObj = {
     result: response,


### PR DESCRIPTION
This fixes #122. The idea is to allow users of the library to write code that is common to all queries.

For example, it would allow to build components like this:
```
module QueryView = {
  let component = ReasonReact.statelessComponent(__MODULE__);

  let make =
      (
        ~result: ReasonApolloTypes.queryResponse('a),
        ~accessData: 'a => option('b),
        ~render: ('b, 'c) => ReasonReact.reactElement,
        ~onLoadMore: ('b, 'unit) => unit=(_, ()) => (),
        _children,
      ) => {
    ...component,
    render: _self =>
      switch (result) {
      | Error(e) => <Error error="" />
      | Loading => ReasonReact.null
      | Data(response) =>
        switch (accessData(response)) {
        | Some(data) => render(data, onLoadMore(data))
        | _ => <Error error="" />
        }
      },
  };
};
```
Which is not possible right now, because the response type is to common to all queries.