### PR TITLE
Change generatedApolloClient method return types to appropriate Js.Promise.t

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -15,7 +15,7 @@ type mutationObj = {
 type generatedApolloClient = {
   .
   "query": [@bs.meth] (queryObj => Js.Promise.t(ReasonApolloQuery.renderPropObjJS)),
-  "mutate": [@bs.meth] (mutationObj => string),
+  "mutate": [@bs.meth] (mutationObj => Js.Promise.t(ReasonApolloMutation.renderPropObjJS)),
 };
 
 type fetch;

--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -14,7 +14,7 @@ type mutationObj = {
 
 type generatedApolloClient = {
   .
-  "query": [@bs.meth] (queryObj => string),
+  "query": [@bs.meth] (queryObj => Js.Promise.t(ReasonApolloQuery.renderPropObjJS)),
   "mutate": [@bs.meth] (mutationObj => string),
 };
 

--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -1,5 +1,15 @@
 open ReasonApolloTypes;
 
+type renderPropObjJS = {
+  .
+  "loading": bool,
+  "called": bool,
+  "data": Js.Nullable.t(Js.Json.t),
+  "error": Js.Nullable.t(apolloError),
+  "networkStatus": int,
+  "variables": Js.Null_undefined.t(Js.Json.t),
+};
+
 module MutationFactory = (Config: Config) => {
   external cast :
     string =>
@@ -24,15 +34,6 @@ module MutationFactory = (Config: Config) => {
     loading: bool,
     error: option(apolloError),
     networkStatus: int,
-  };
-  type renderPropObjJS = {
-    .
-    "loading": bool,
-    "called": bool,
-    "data": Js.Nullable.t(Js.Json.t),
-    "error": Js.Nullable.t(apolloError),
-    "networkStatus": int,
-    "variables": Js.Null_undefined.t(Js.Json.t),
   };
   type apolloMutation =
     (~variables: Js.Json.t=?, ~refetchQueries: array(string)=?, unit) =>

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -1,6 +1,5 @@
 open ReasonApolloTypes;
 
-
 [@bs.deriving abstract]
 type updateQueryOptions = {
   [@bs.optional]
@@ -10,15 +9,12 @@ type updateQueryOptions = {
 };
 
 type onErrorT;
-
 type updateQueryT = (Js.Json.t, updateQueryOptions) => Js.Json.t;
-
 type updateSubscriptionOptions = {
   .
   "subscriptionData": Js.Nullable.t(Js.Json.t),
   "variables": Js.Nullable.t(Js.Json.t),
 };
-
 type updateQuerySubscriptionT = (Js.Json.t, updateSubscriptionOptions) => Js.Json.t;
 
 [@bs.deriving abstract]

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -1,5 +1,54 @@
 open ReasonApolloTypes;
 
+
+[@bs.deriving abstract]
+type updateQueryOptions = {
+  [@bs.optional]
+  fetchMoreResult: Js.Json.t,
+  [@bs.optional]
+  variables: Js.Json.t,
+};
+
+type onErrorT;
+
+type updateQueryT = (Js.Json.t, updateQueryOptions) => Js.Json.t;
+
+type updateSubscriptionOptions = {
+  .
+  "subscriptionData": Js.Nullable.t(Js.Json.t),
+  "variables": Js.Nullable.t(Js.Json.t),
+};
+
+type updateQuerySubscriptionT = (Js.Json.t, updateSubscriptionOptions) => Js.Json.t;
+
+[@bs.deriving abstract]
+type subscribeToMoreOptions = {
+  document: queryString,
+  [@bs.optional] variables: Js.Json.t,
+  [@bs.optional] updateQuery: updateQuerySubscriptionT,
+  [@bs.optional] onError: onErrorT
+};
+
+/* We dont accept a new query for now */
+[@bs.deriving abstract]
+type fetchMoreOptions = {
+  [@bs.optional]
+  variables: Js.Json.t,
+  updateQuery: updateQueryT,
+};
+
+[@bs.deriving abstract]
+type renderPropObjJS = {
+  loading: bool,
+  data: Js.Nullable.t(Js.Json.t),
+  error: Js.Nullable.t(apolloError),
+  refetch: Js.Null_undefined.t(Js.Json.t) => Js.Promise.t(renderPropObjJS),
+  networkStatus: int,
+  variables: Js.Null_undefined.t(Js.Json.t),
+  fetchMore: fetchMoreOptions => Js.Promise.t(unit),
+  subscribeToMore: subscribeToMoreOptions => unit => unit,
+};
+
 module Get = (Config: ReasonApolloTypes.Config) => {
   [@bs.module] external gql : ReasonApolloTypes.gql = "graphql-tag";
   [@bs.module "react-apollo"]
@@ -8,41 +57,6 @@ module Get = (Config: ReasonApolloTypes.Config) => {
     | Loading
     | Error(apolloError)
     | Data(Config.t);
-
-  [@bs.deriving abstract]
-  type updateQueryOptions = {
-    [@bs.optional]
-    fetchMoreResult: Js.Json.t,
-    [@bs.optional]
-    variables: Js.Json.t,
-  };
-
-  type updateQueryT = (Js.Json.t, updateQueryOptions) => Js.Json.t;
-
-  /* We dont accept a new query for now */
-  [@bs.deriving abstract]
-  type fetchMoreOptions = {
-    [@bs.optional]
-    variables: Js.Json.t,
-    updateQuery: updateQueryT,
-  };
-  
-  type updateSubscriptionOptions = {
-    .
-    "subscriptionData": Js.Nullable.t(Js.Json.t),
-    "variables": Js.Nullable.t(Js.Json.t),
-  };
-
-  type updateQuerySubscriptionT = (Js.Json.t, updateSubscriptionOptions) => Js.Json.t;
-  type onErrorT;
-
-  [@bs.deriving abstract] 
-  type subscribeToMoreOptions = {
-    document: queryString,
-    [@bs.optional] variables: Js.Json.t,
-    [@bs.optional] updateQuery: updateQuerySubscriptionT,
-    [@bs.optional] onError: onErrorT 
-  };
 
   type renderPropObj = {
     result: response,
@@ -55,18 +69,6 @@ module Get = (Config: ReasonApolloTypes.Config) => {
       Js.Promise.t(unit),
     networkStatus: int,
     subscribeToMore: (~document: queryString, ~variables: Js.Json.t=?, ~updateQuery: updateQuerySubscriptionT=?, ~onError: onErrorT=?, unit) => unit => unit
-  };
-
-  [@bs.deriving abstract]
-  type renderPropObjJS = {
-    loading: bool,
-    data: Js.Nullable.t(Js.Json.t),
-    error: Js.Nullable.t(apolloError),
-    refetch: Js.Null_undefined.t(Js.Json.t) => Js.Promise.t(renderPropObjJS),
-    networkStatus: int,
-    variables: Js.Null_undefined.t(Js.Json.t),
-    fetchMore: fetchMoreOptions => Js.Promise.t(unit),
-    subscribeToMore: subscribeToMoreOptions => unit => unit,
   };
 
   let graphqlQueryAST = gql(. Config.query);
@@ -113,7 +115,7 @@ module Get = (Config: ReasonApolloTypes.Config) => {
     fetchMore: (~variables=?, ~updateQuery, ()) =>
       apolloData |. fetchMore(fetchMoreOptions(~variables?, ~updateQuery, ())),
     networkStatus: apolloData |.networkStatus,
-    subscribeToMore: (~document, ~variables=?, ~updateQuery=?, ~onError=?, ()) => 
+    subscribeToMore: (~document, ~variables=?, ~updateQuery=?, ~onError=?, ()) =>
     apolloData |. subscribeToMore(subscribeToMoreOptions(
       ~document,
       ~variables?,


### PR DESCRIPTION
The query and mutate methods of generatedApolloClient are currently unusable as they are typed to return strings instead of Js.Promise.t.
This PR is meant to allow people to use these methods to fetch data directly, to mimic the client.query(...) behavior on the Apollo getting started page: https://www.apollographql.com/docs/react/essentials/get-started.html

**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
