### PR TITLE
Add support for ReadQuery and WriteQuery

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -46,3 +46,54 @@ external apolloClientObjectParam :
   ) =>
   _ =
   "";
+
+module ReadQuery = (Config: ReasonApolloTypes.Config) => {
+  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  type readQueryOptions = {
+    .
+    "query": queryString,
+    "variables": Js.Nullable.t(Js.Json.t),
+  };
+  [@bs.send]
+  external readQuery: (generatedApolloClient, readQueryOptions) => Config.t =
+    "";
+  type response = option(Config.t);
+
+  let graphqlQueryAST = gql(. Config.query);
+  let apolloDataToRecord: Js.Nullable.t(Js.Json.t) => response =
+    apolloData =>
+      Js.Nullable.toOption(apolloData)->(Belt.Option.map(Config.parse));
+
+  let make = (~client, ~variables: option(Js.Json.t)=?, ()) =>
+    readQuery(
+      client,
+      {
+        "query": graphqlQueryAST,
+        "variables": Js.Nullable.fromOption(variables),
+      },
+    );
+};
+
+module WriteQuery = (Config: ReasonApolloTypes.Config) => {
+  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  type writeQueryOptions = {
+    .
+    "query": ReasonApolloTypes.queryString,
+    "variables": Js.Nullable.t(Js.Json.t),
+    "data": Config.t,
+  };
+  [@bs.send]
+  external writeQuery: (generatedApolloClient, writeQueryOptions) => unit = "";
+
+  let graphqlQueryAST = gql(. Config.query);
+
+  let make = (~client, ~variables: option(Js.Json.t)=?, ~data: Config.t, ()) =>
+    writeQuery(
+      client,
+      {
+        "query": graphqlQueryAST,
+        "variables": Js.Nullable.fromOption(variables),
+        "data": data,
+      },
+    );
+};


### PR DESCRIPTION
This adds support for ReadQuery and WriteQuery directly from the ApolloClient.

I feel like this should be placed in the ApolloClient module, but it might be a better idea to have them as separate modules and then include them in ApolloClient.
**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
