### PR TITLE
Feature: Apollo Upload Client ( createUploadLink )

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add reason-apollo
 yarn add --dev graphql_ppx
 
 # Add JS dependencies
-yarn add react-apollo apollo-client apollo-cache-inmemory apollo-link apollo-link-context apollo-link-error apollo-link-http graphql graphql-tag apollo-link-ws subscriptions-transport-ws
+yarn add react-apollo apollo-client apollo-cache-inmemory apollo-link apollo-link-context apollo-link-error apollo-link-http graphql graphql-tag apollo-link-ws apollo-upload-client subscriptions-transport-ws
 ```
 
 #### bsconfig

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "apollo-client": "^2.3.1",
     "apollo-link": "^1.2.2",
     "apollo-link-http": "^1.5.4",
+    "apollo-upload-client": "^9.0.0",
     "apollo-utilities": "^1.0.16",
     "bs-platform": "^4.0.5",
     "graphql": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "apollo-link": "^1.2.2",
     "apollo-link-http": "^1.5.4",
     "apollo-link-ws": "^1.0.8",
+    "apollo-upload-client": "^9.0.0",
     "bs-platform": "^4.0.5",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.9.2",

--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -31,6 +31,16 @@ type linkOptions = {
   "fetchOptions": Js.Nullable.t(Js.Json.t),
 };
 
+type uploadLinkOptions = {
+  .
+  "uri": Js.Nullable.t(string),
+  "fetch": Js.Nullable.t(fetch),
+  "fetchOptions": Js.Nullable.t(Js.t({.})),
+  "credentials": Js.Nullable.t(string),
+  "headers": Js.Nullable.t(Js.Json.t),
+  "includeExtensions": Js.Nullable.t(bool),
+};
+
 [@bs.module "apollo-client"] [@bs.new]
 external createApolloClientJS : 'a => generatedApolloClient = "ApolloClient";
 

--- a/src/ApolloLinks.re
+++ b/src/ApolloLinks.re
@@ -18,6 +18,11 @@ open ReasonApolloTypes;
 /* bind apollo-link-ws */
 [@bs.module "apollo-link-ws"] [@bs.new] external webSocketLink : webSocketLinkT  => apolloLink = "WebSocketLink";
 
+/* Bind createUploadLink function from apollo upload link */
+[@bs.module "apollo-upload-client"]
+external createUploadLink: ApolloClient.uploadLinkOptions => apolloLink =
+  "createUploadLink";
+
 let webSocketLink = (
   ~uri,
   ~reconnect=?,
@@ -50,6 +55,31 @@ let createHttpLink = (
 };
 
 /**
+ * CreateUploadLink
+ * https://github.com/jaydenseric/apollo-upload-client#function-createuploadlink
+ */
+let createUploadLink =
+    (
+      ~uri=?,
+      ~fetch=?,
+      ~fetchOptions=?,
+      ~credentials=?,
+      ~headers=?,
+      ~includeExtensions=?,
+      (),
+    ) =>
+  createUploadLink(
+    Js.Nullable.{
+      "uri": fromOption(uri),
+      "fetch": fromOption(fetch),
+      "fetchOptions": fromOption(fetchOptions),
+      "credentials": fromOption(credentials),
+      "headers": fromOption(headers),
+      "includeExtensions": fromOption(includeExtensions),
+    },
+  );
+
+/**
  * CreateContextLink
  * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-context
  */
@@ -66,4 +96,3 @@ let createErrorLink = (errorHandler) => {
   /* Instanciate a new error link object */
   apolloLinkOnError(errorHandler);
 };
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,12 @@ apollo-link-http-common@^0.2.4:
   dependencies:
     apollo-link "^1.2.2"
 
+apollo-link-http-common@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.5.tgz#d094beb7971523203359bf830bfbfa7b4e7c30ed"
+  dependencies:
+    apollo-link "^1.2.3"
+
 apollo-link-http@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.4.tgz#b80b7b4b342c655b6a5614624b076a36be368f43"
@@ -91,6 +97,21 @@ apollo-link@^1.0.0, apollo-link@^1.2.2:
     "@types/graphql" "0.12.6"
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.9"
+
+apollo-link@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.3.tgz#9bd8d5fe1d88d31dc91dae9ecc22474d451fb70d"
+  dependencies:
+    apollo-utilities "^1.0.0"
+    zen-observable-ts "^0.8.10"
+
+apollo-upload-client@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-9.0.0.tgz#94edaf116b70491f0a2d872a1746da7b788f9c0f"
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-link-http-common "^0.2.5"
+    extract-files "^4.0.0"
 
 apollo-utilities@1.0.20, apollo-utilities@^1.0.0, apollo-utilities@^1.0.20:
   version "1.0.20"
@@ -222,6 +243,10 @@ execa@^0.7.0:
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
+extract-files@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-4.0.0.tgz#a5bbcac16d753a7b7c74fbda1d4992424bfa5fa4"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -793,6 +818,12 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+zen-observable-ts@^0.8.10:
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz#18e2ce1c89fe026e9621fd83cc05168228fce829"
+  dependencies:
+    zen-observable "^0.8.0"
 
 zen-observable-ts@^0.8.9:
   version "0.8.9"


### PR DESCRIPTION
**Apollo Upload Client Binding**

hi there 🙂
If possible I would like to merge this PR which binds [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client), as createUploadLink requires the type from apolloLink to be working with reason-apollo package.
it enables us to send [multipart-request](https://github.com/jaydenseric/graphql-multipart-request-spec)
So that reason-apollo would provide upload client out of the box if needed 🎉

__example__ :
```
let uploadLink =
  ApolloUploadClient.createUploadLink(~uri=ApiConfig.baseURL(`graphql), ());

let instance =
  ReasonApollo.createApolloClient(
    ~link=ApolloLinks.from([|uploadLink|]),
    ~cache=inMemoryCache,
    (),
  );
```

thanks before.
<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [x] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->


