### PR TITLE
update bs-platform to 4.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "apollo-link-http": "^1.5.4",
     "apollo-link-ws": "^1.0.8",
     "apollo-upload-client": "^9.0.0",
-    "bs-platform": "^4.0.5",
+    "bs-platform": "^4.0.7",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.9.2",
     "graphql_ppx": "^0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,8 +152,8 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 bs-platform@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.5.tgz#d4fd9bbdd11765af5b75110a5655065ece05eed6"
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.7.tgz#1a0bbf0fef439fef5f1a88ba60d5ac8a6d73570c"
 
 camelcase@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION

**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] docs
- [x] blocking

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
fix 
```
WARNING in ./node_modules/reason-apollo/src/graphql-types/ReasonApolloMutation.bs.js 62:23-57
"export 'null_undefined_to_opt' (imported as 'Js_primitive') was not found in 'bs-platform/lib/es6/js_primitive.js'
 @ ./node_modules/reason-apollo/src/ReasonApollo.bs.js
 @ ./src/client/ApolloClient.bs.js
 @ ./src/index.bs.js
```