### PR TITLE
add optimisticResponse to mutation call

### DIFF
--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -32,12 +32,22 @@ module Make = (Config: Config) => {
     networkStatus: option(int),
   };
   type apolloMutation =
-    (~variables: Js.Json.t=?, ~refetchQueries: array(string)=?, unit) =>
+    (
+      ~variables: Js.Json.t=?,
+      ~refetchQueries: array(string)=?,
+      ~optimisticResponse: Config.t=?,
+      unit
+    ) =>
     Js.Promise.t(executionResponse(Config.t));
 
   [@bs.obj]
   external makeMutateParams:
-    (~variables: Js.Json.t=?, ~refetchQueries: array(string)=?) => _ =
+    (
+      ~variables: Js.Json.t=?,
+      ~refetchQueries: array(string)=?,
+      ~optimisticResponse: Config.t=?
+    ) =>
+    _ =
     "";
 
   let convertExecutionResultToReason = (executionResult: executionResult) =>
@@ -50,8 +60,16 @@ module Make = (Config: Config) => {
     | (None, None) => EmptyResponse
     };
   let apolloMutationFactory =
-      (~jsMutation, ~variables=?, ~refetchQueries=?, ()) =>
-    jsMutation(makeMutateParams(~variables?, ~refetchQueries?))
+      (
+        ~jsMutation,
+        ~variables=?,
+        ~refetchQueries=?,
+        ~optimisticResponse=?,
+        (),
+      ) =>
+    jsMutation(
+      makeMutateParams(~variables?, ~refetchQueries?, ~optimisticResponse?),
+    )
     |> Js.Promise.(
          then_(response => resolve(convertExecutionResultToReason(response)))
        );


### PR DESCRIPTION

**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
