### PR TITLE
Feature/mutation-onError

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "author": "Grégoire Van der Auwermeulen <gregoirevandera@gmail.com>",
   "devDependencies": {
-    "bs-platform": "^4.0.7",
+    "bs-platform": "^5.0.0",
     "graphql_ppx": "^0.2.8",
     "husky": "^1.2.0",
     "lint-staged": "^8.1.0",

--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -103,7 +103,7 @@ module Make = (Config: Config) => {
   let make =
       (
         ~variables: option(Js.Json.t)=?,
-        ~onError: option(unit => unit)=?,
+        ~onError: option(apolloError => unit)=?,
         ~onCompleted: option(unit => unit)=?,
         children: (apolloMutation, renderPropObj) => ReasonReact.reactElement,
       ) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,10 +309,10 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-bs-platform@^4.0.7:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.8.tgz#d7b1ee9b21efdb549669dff797f578e229bcbe20"
-  integrity sha512-pTsVLNQ/CNuYUYmhlxhQyuJSACFi7v1avhX5qx6TxzAR3jXjMvImz8WdT+zzzJyisY2TTjMvCrJwhefT3Dliqw==
+bs-platform@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.0.tgz#f9fded818bafc3891aeb85eb4e0d95b8d8f8b4d7"
+  integrity sha512-zxLobdIaf/r7go47hOgxcd6C0ANh7MYMEtZNb9Al7JdoekzFZI50F4GpZpP8kMh9Z+M5PoPE1WuryT4S8mT8Kg==
 
 builtin-modules@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
* `yarn install` fails on bs-platform 4.x so I bumped it to 5.x
* I added correct type to `onError` from https://www.apollographql.com/docs/react/essentials/mutations.html#props

That being said, using `onError` is not too useful as it's still required to handle the promise from calling the `mutation` renderProp as otherwise you'll have trouble with uncaught errors as `.catch` is not called.

Example:
```re
yourQuery.make(...args...)##variables
  |> mutation(~variables=_, ~refetchQueries=[|"...something..."|], ())
  // to get correct return type for catch:
  |> Js.Promise.then_(_ => Js.Promise.resolve(()))
  // catch so no trouble with uncaught errors
  |> Js.Promise.catch(_error => Js.Promise.resolve(()))
```

Not the most useful PR, but do what ya will with it!