### PR TITLE
move mutation renderPropObjJS to separate module (fix cyclical dep is…

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -18,7 +18,7 @@ type generatedApolloClient = {
     [@bs.meth] (queryObj => Js.Promise.t(ReasonApolloQuery.renderPropObjJS)),
   "mutate":
     [@bs.meth] (
-      mutationObj => Js.Promise.t(ReasonApolloMutation.renderPropObjJS)
+      mutationObj => Js.Promise.t(ReasonApolloMutationTypes.renderPropObjJS)
     ),
   "resetStore": [@bs.meth] (unit => Js.Promise.t(unit)),
 };

--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -1,14 +1,5 @@
 open ReasonApolloTypes;
-
-type renderPropObjJS = {
-  .
-  "loading": bool,
-  "called": bool,
-  "data": Js.Nullable.t(Js.Json.t),
-  "error": Js.Nullable.t(apolloError),
-  "networkStatus": Js.Nullable.t(int),
-  "variables": Js.Null_undefined.t(Js.Json.t),
-};
+open ReasonApolloMutationTypes;
 
 module Make = (Config: Config) => {
   external cast:

--- a/src/graphql-types/ReasonApolloMutationTypes.re
+++ b/src/graphql-types/ReasonApolloMutationTypes.re
@@ -1,0 +1,9 @@
+type renderPropObjJS = {
+  .
+  "loading": bool,
+  "called": bool,
+  "data": Js.Nullable.t(Js.Json.t),
+  "error": Js.Nullable.t(ReasonApolloTypes.apolloError),
+  "networkStatus": Js.Nullable.t(int),
+  "variables": Js.Null_undefined.t(Js.Json.t),
+};


### PR DESCRIPTION
#183 caused a cyclical dep issue

this fixes it, however, this might also break backwards compat as someone might be including `renderPropObjJS` from `ReasonApolloMutation`

