### PR TITLE
Change graphql-tag import to default jsx3-hooks

### DIFF
--- a/examples/realtime-chat-application/src/MessagesContainer.re
+++ b/examples/realtime-chat-application/src/MessagesContainer.re
@@ -2,16 +2,14 @@
 
 module Styles = {
   open Css;
-  let container =
-    style([
-      margin(px(20)),
-      padding(px(5)),
-      boxShadow(~x=px(2), ~y=px(2), grey),
-    ]);
+  let container = style([
+    margin(px(20)),
+    padding(px(5)),
+    boxShadow(~x=px(2), ~y=px(2), grey) 
+  ]);
 };
 
-module GetAllMessages = [%graphql
-  {|
+module GetAllMessages = [%graphql {|
   {
     messages {
       id
@@ -22,13 +20,12 @@ module GetAllMessages = [%graphql
       }
     }
   }
-|}
-];
+|}];
 
 module GetAllMessagesQuery = ReasonApollo.CreateQuery(GetAllMessages);
 
-module MessageAdded = [%graphql
-  {|
+
+module MessageAdded = [%graphql {|
 subscription messageAdded {
   messageAdded {
     id
@@ -39,8 +36,7 @@ subscription messageAdded {
     }
   }
 }
-|}
-];
+|}];
 
 let messageAdded = MessageAdded.make();
 let messageAddedASTQuery = gql(. messageAdded##query);
@@ -49,43 +45,38 @@ let component = ReasonReact.statelessComponent("Messages");
 
 let make = _children => {
   ...component,
-  render: _self =>
-    <div className=Styles.container>
-      <GetAllMessagesQuery>
-        ...{({result, subscribeToMore}) =>
-          switch (result) {
-          | Loading => <div> {"Loading" |> ReasonReact.string} </div>
-          | Error(_e) => <div> {"Error" |> ReasonReact.string} </div>
-          | Data(response) =>
-            <Messages
-              onLoad={() => {
-                let _unsub =
-                  subscribeToMore(
+  render: _self => <div className=Styles.container>
+    <GetAllMessagesQuery>
+      ...{
+        ({result, subscribeToMore}) => switch result {
+            | Loading => <div> {"Loading" |> ReasonReact.string} </div>
+            | Error(_e) => <div> {"Error" |> ReasonReact.string} </div>
+            | Data(response) => 
+              <Messages 
+                onLoad={
+                  () => {
+                  let _unsub = subscribeToMore(
                     ~document=messageAddedASTQuery,
-                    ~updateQuery=
-                      (prev, next) => {
-                        let addNewMessageJS = [%bs.raw
-                          {|
+                    ~updateQuery={(prev, next) => {
+                      let addNewMessageJS = [%bs.raw {|
                           function(prev, next) {
                             if(!next.subscriptionData.data || !next.subscriptionData.data.messageAdded)
                               return prev;
-
                             return Object.assign({}, prev, {
                               messages: prev.messages.concat(next.subscriptionData.data.messageAdded)
                             });
                           }
-                      |}
-                        ];
-                        addNewMessageJS(prev, next);
-                      },
-                    (),
-                  );
-                ();
-              }}
-              messages=response##messages
-            />
-          }
-        }
-      </GetAllMessagesQuery>
-    </div>,
+                      |}];
+                      addNewMessageJS(prev, next);
+                    }},
+                    ()
+                  )
+                }
+                } 
+                messages=(response##messages) 
+              />
+          } 
+      }
+    </GetAllMessagesQuery>
+</div>
 };

--- a/examples/swapi/src/PersonSubscribeToMore.re
+++ b/examples/swapi/src/PersonSubscribeToMore.re
@@ -1,4 +1,4 @@
-[@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
 
 let ste = React.string;
 

--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -48,6 +48,8 @@ type uploadLinkOptions = {
 [@bs.module "apollo-client"] [@bs.new]
 external createApolloClientJS: 'a => generatedApolloClient = "ApolloClient";
 
+[@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
+
 [@bs.obj]
 external apolloClientObjectParam:
   (
@@ -62,7 +64,6 @@ external apolloClientObjectParam:
   "";
 
 module ReadQuery = (Config: ReasonApolloTypes.Config) => {
-  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
   type readQueryOptions = {
     .
     "query": ReasonApolloTypes.queryString,
@@ -91,7 +92,6 @@ module ReadQuery = (Config: ReasonApolloTypes.Config) => {
 };
 
 module WriteQuery = (Config: ReasonApolloTypes.Config) => {
-  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
   type writeQueryOptions = {
     .
     "query": ReasonApolloTypes.queryString,

--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -20,7 +20,7 @@ module Make = (Config: Config) => {
     } =
     "%identity";
 
-  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
 
   let graphqlMutationAST = gql(. Config.query);
   type response = mutationResponse(Config.t);

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -50,7 +50,7 @@ type renderPropObjJS = {
 };
 
 module Make = (Config: ReasonApolloTypes.Config) => {
-  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
 
   type response = queryResponse(Config.t);
 

--- a/src/graphql-types/ReasonApolloSubscription.re
+++ b/src/graphql-types/ReasonApolloSubscription.re
@@ -1,7 +1,7 @@
 open ReasonApolloTypes;
 
 module Make = (Config: ReasonApolloTypes.Config) => {
-  [@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag";
+  [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";
 
   let graphQLSubscriptionAST = gql(. Config.query);
 


### PR DESCRIPTION
**Pull Request Labels**

- [ ] feature
- [x] fix
- [ ] blocking
- [ ] docs

Hey :)
`[@bs.module] external gql: ReasonApolloTypes.gql = "graphql-tag"` in specific situations causes issues (jest testing in my case). Switching to  `[@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default"` is safe and causes no such problems.
Similar to https://github.com/apollographql/reason-apollo/pull/80 but for jsx3 branch.
@Gregoirevda 

