### PR TITLE
Use getNonEmptyObj in apolloDataToVariant

### DIFF
--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -80,7 +80,7 @@ module Make = (Config: ReasonApolloTypes.Config) => {
     apolloData =>
       switch (
         apolloData->loadingGet,
-        apolloData->dataGet |> Js.Nullable.toOption,
+        apolloData->dataGet |> ReasonApolloUtils.getNonEmptyObj,
         apolloData->errorGet |> Js.Nullable.toOption,
       ) {
       | (true, _, _) => Loading


### PR DESCRIPTION
Match the behavior of `convertJsInputToReason` and don't run the `parse` function
when the data object is empty. This prevents runtime crashes of the parse function
in this case. This seems like a safe thing to do because it makes the handling of
`apolloData.data` more consistent between `apolloDataToVariant` and `convertJsInputToReason`.

### More context/explanation:
I'm no graphql expert, so I've had some trouble understanding exactly why
this is happening and build a small reproducible example, but this seems to be a fix that
makes sense and is working in our code.

I've been getting errors similar to the following when multiple different queries include the same field (in this case, "ownedWallets").
```
js_exn.js:6 Uncaught Error: graphql_ppx: Field ownedWallets on type Query is missing
    at Object.raiseError (js_exn.js:6)
    at parse (SideBar.js:123)
    at Object._1 (curry.js:65)
    at apolloDataToVariant (ReasonApolloQuery.bs.js:32)
    at convertJsInputToReason (ReasonApolloQuery.bs.js:57)
    at Object.children (ReasonApolloQuery.bs.js:125)
    at finish (react-apollo.browser.umd.js:470)
    at Query.render (react-apollo.browser.umd.js:474)
    at finishClassComponent (react-dom.development.js:14741)
    at updateClassComponent (react-dom.development.js:14696)
```

When inspecting the input to `convertJsInputToReason `, it's getting an apolloData object with a `data` field that is just an empty object (even though loading is false and there are no errors). 
This gets passed to `apolloDataToVariant`, which tries to run the `parse` function (generated by graphql_ppx) because `apolloData.data` is not null (it's `{}`). `parse` then crashes with the above error because none of the required fields are in the object, obviously.

From my inexpert debugging, the root cause of the empty data seems to be caused by
something caching-related cause it doesn't seem to happen with caching turned off,
but this fix stops the crashing, and renders with an error "No data" in this case.

When combined with `partialRefetch=true`, there is no crash and no error and life is great :)

/label bugfix
