### PR TITLE
accept connectionParams as an argument to webSocketLink (closes #198)

### DIFF
--- a/src/ApolloLinks.re
+++ b/src/ApolloLinks.re
@@ -1,57 +1,67 @@
 open ReasonApolloTypes;
 
 /* Bind the method `from`, used to compose links together */
-[@bs.module "apollo-link"] external from : array(apolloLink) => apolloLink = "from";
+[@bs.module "apollo-link"]
+external from: array(apolloLink) => apolloLink = "from";
 
 /* Bind the method split. Based on a test send left or right */
-[@bs.module "apollo-link"] external split : (splitTest => bool) => apolloLink => apolloLink => apolloLink = "split";
+[@bs.module "apollo-link"]
+external split: (splitTest => bool, apolloLink, apolloLink) => apolloLink =
+  "split";
 
 /* Bind the HttpLink class */
-[@bs.module "apollo-link-http"] [@bs.new] external createHttpLink : ApolloClient.linkOptions => apolloLink = "HttpLink";
+[@bs.module "apollo-link-http"] [@bs.new]
+external createHttpLink: ApolloClient.linkOptions => apolloLink = "HttpLink";
 
 /* Bind the setContext method */
-[@bs.module "apollo-link-context"] external apolloLinkSetContext : (unit => Js.t({..})) => apolloLink = "setContext";
+[@bs.module "apollo-link-context"]
+external apolloLinkSetContext: (unit => Js.t({..})) => apolloLink =
+  "setContext";
 
 /* Bind the onError method */
-[@bs.module "apollo-link-error"] external apolloLinkOnError : (errorResponse => unit) => apolloLink = "onError";
+[@bs.module "apollo-link-error"]
+external apolloLinkOnError: (errorResponse => unit) => apolloLink = "onError";
 
 /* bind apollo-link-ws */
-[@bs.module "apollo-link-ws"] [@bs.new] external webSocketLink : webSocketLinkT  => apolloLink = "WebSocketLink";
+[@bs.module "apollo-link-ws"] [@bs.new]
+external webSocketLink: webSocketLinkT => apolloLink = "WebSocketLink";
 
 /* Bind createUploadLink function from apollo upload link */
 [@bs.module "apollo-upload-client"]
 external createUploadLink: ApolloClient.uploadLinkOptions => apolloLink =
   "createUploadLink";
 
-let webSocketLink = (
-  ~uri,
-  ~reconnect=?,
-  ()
-) => {
-  webSocketLink(webSocketLinkT(~uri=uri, ~options=webSocketLinkOptionsT(~reconnect=?reconnect, ())));
-}; 
+let webSocketLink = (~uri, ~reconnect=?, ~connectionParams=?, ()) => {
+  webSocketLink(
+    webSocketLinkT(
+      ~uri,
+      ~options=webSocketLinkOptionsT(~reconnect?, ~connectionParams?, ()),
+    ),
+  );
+};
 
 /**
  * CreateHttpLink
  * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http
  */
-let createHttpLink = (
-~uri,
-~includeExtensions=?,
-~fetch=?,
-~headers=?,
-~credentials=?,
-~fetchOptions=?,
-()
-) => {
-    createHttpLink({
-      "uri": uri,
-      "includeExtensions": Js.Nullable.fromOption(includeExtensions),
-      "fetch": Js.Nullable.fromOption(fetch),
-      "headers": Js.Nullable.fromOption(headers),
-      "credentials": Js.Nullable.fromOption(credentials),
-      "fetchOptions": Js.Nullable.fromOption(fetchOptions)
-    });
+let createHttpLink =
+    (
+      ~uri,
+      ~includeExtensions=?,
+      ~fetch=?,
+      ~headers=?,
+      ~credentials=?,
+      ~fetchOptions=?,
+      (),
+    ) => {
+  createHttpLink({
+    "uri": uri,
+    "includeExtensions": Js.Nullable.fromOption(includeExtensions),
+    "fetch": Js.Nullable.fromOption(fetch),
+    "headers": Js.Nullable.fromOption(headers),
+    "credentials": Js.Nullable.fromOption(credentials),
+    "fetchOptions": Js.Nullable.fromOption(fetchOptions),
+  });
 };
 
 /**
@@ -83,16 +93,18 @@ let createUploadLink =
  * CreateContextLink
  * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-context
  */
-let createContextLink = (contextHandler) => {
+let createContextLink = contextHandler => {
   /* Instanciate a new context link object */
-  apolloLinkSetContext(contextHandler);
+  apolloLinkSetContext(
+    contextHandler,
+  );
 };
 
 /**
  * CreateErrorLink
  * https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-error
  */
-let createErrorLink = (errorHandler) => {
+let createErrorLink = errorHandler => {
   /* Instanciate a new error link object */
   apolloLinkOnError(errorHandler);
 };

--- a/src/ReasonApolloTypes.re
+++ b/src/ReasonApolloTypes.re
@@ -8,7 +8,7 @@ type queryString;
  * query string to the standard GraphQL AST.
  * https://github.com/apollographql/graphql-tag
  */
-type gql = [@bs] (string => queryString);
+type gql = (. string) => queryString;
 
 /**
  * An abstract type to describe an Apollo Link object.
@@ -41,36 +41,37 @@ type executionResult = {
 };
 
 /* TODO define all types */
-type operation = {
-  .
-  "query": queryString
-};
+type operation = {. "query": queryString};
 
 /* TODO define subscription */
 type subscription;
 
 type errorResponse = {
-  . 
+  .
   "graphQLErrors": Js.Nullable.t(Js.Array.t(graphqlError)),
   "networkError": Js.Nullable.t(networkError),
   "response": Js.Nullable.t(executionResult),
-  "operation": operation ,
+  "operation": operation,
   "forward": operation => subscription,
 };
 
-module type Config = {let query: string; type t; let parse: Js.Json.t => t;};
+module type Config = {
+  let query: string;
+  type t;
+  let parse: Js.Json.t => t;
+};
 
 type apolloError = {
   .
   "message": string,
   "graphQLErrors": Js.Nullable.t(array(graphqlError)),
-  "networkError": Js.Nullable.t(string)
+  "networkError": Js.Nullable.t(string),
 };
 
 type apolloOptions = {
-    .
-    "query": queryString,
-    "variables": Js.Json.t,
+  .
+  "query": queryString,
+  "variables": Js.Json.t,
 };
 
 type queryResponse('a) =
@@ -93,25 +94,24 @@ type executionResponse('a) =
   | Errors(array(graphqlError))
   | EmptyResponse
   | Data('a);
-/* 
+/*
  apollo link ws
  */
 
-
 [@bs.deriving abstract]
 type webSocketLinkOptionsT = {
-  [@bs.optional] reconnect: bool
+  [@bs.optional]
+  reconnect: bool,
+  [@bs.optional]
+  connectionParams: Js.Json.t,
 };
 
 [@bs.deriving abstract]
 type webSocketLinkT = {
   uri: string,
-  options: webSocketLinkOptionsT
+  options: webSocketLinkOptionsT,
 };
 
 type documentNodeT;
 
-type splitTest = {
-  .
-  "query": documentNodeT
-};
+type splitTest = {. "query": documentNodeT};


### PR DESCRIPTION
Accept `connectionParams` of type `Js.Json.t` to webSocketLink.

**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [x] feature
- [ ] blocking
- [ ] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
