### PR TITLE
correct name for ppx-flags is bsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add --dev graphql_ppx
 
 #### bsconfig
 Add `reason-apollo` to your `bs-dependencies` and
-`graphql_ppx/ppx` to your `ppx_flags`
+`graphql_ppx/ppx` to your `ppx-flags`
 
 **bsconfig.json**
 ```


### PR DESCRIPTION
Ran into similar issue to this issue here https://github.com/apollographql/reason-apollo/issues/136#issuecomment-424637975

Nitpick, but hopefully fixing the `ppx-flags` property name in bsconfig will help.
**Pull Request Labels**

<!--
While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-->

- [ ] feature
- [ ] blocking
- [x] docs

<!--
You are also able to add labels by placing /label on a new line
followed by the label you would like to add. ex: /label discussion
-->
