### PR TITLE
Fix ReasonReact optional args bug

### DIFF
--- a/src/graphql-types/ReasonApolloMutation.re
+++ b/src/graphql-types/ReasonApolloMutation.re
@@ -1,4 +1,6 @@
 open ReasonApolloTypes;
+/* Silence the warning about shadowing Error from Stdlib */
+[@ocaml.warning "-45"];
 
 type renderPropObjJS = {
   loading: bool,
@@ -126,12 +128,12 @@ module Make = (Config: Config) => {
   [@react.component]
   let make =
       (
-        ~variables: Js.Json.t=?,
-        ~onError: apolloError => unit=?,
-        ~onCompleted: unit => unit=?,
+        ~variables: option(Js.Json.t)=?,
+        ~onError: option(apolloError => unit)=?,
+        ~onCompleted: option(unit => unit)=?,
         ~children: (apolloMutation, renderPropObj) => React.element,
       ) =>
-    <JsMutation mutation=graphqlMutationAST variables onError onCompleted>
+    <JsMutation mutation=graphqlMutationAST ?variables ?onError ?onCompleted>
       {(mutation, apolloData) =>
          children(
            apolloMutationFactory(~jsMutation=mutation),

--- a/src/graphql-types/ReasonApolloQuery.re
+++ b/src/graphql-types/ReasonApolloQuery.re
@@ -1,4 +1,6 @@
 open ReasonApolloTypes;
+/* Silence the warning about shadowing Error from Stdlib */
+[@ocaml.warning "-45"];
 
 type updateQueryOptions = {
   fetchMoreResult: option(Js.Json.t),
@@ -148,36 +150,36 @@ module Make = (Config: ReasonApolloTypes.Config) => {
   [@react.component]
   let make =
       (
-        ~variables: Js.Json.t=?,
-        ~pollInterval: int=?,
-        ~notifyOnNetworkStatusChange: bool=?,
-        ~fetchPolicy: string=?,
-        ~errorPolicy: string=?,
-        ~ssr: bool=?,
-        ~displayName: string=?,
-        ~skip: bool=?,
-        ~onCompleted: Js.Nullable.t(Js.Json.t) => unit=?,
-        ~onError: apolloError => unit=?,
-        ~partialRefetch: bool=?,
-        ~delay: bool=?,
-        ~context: Js.Json.t=?,
+        ~variables: option(Js.Json.t)=?,
+        ~pollInterval: option(int)=?,
+        ~notifyOnNetworkStatusChange: option(bool)=?,
+        ~fetchPolicy: option(string)=?,
+        ~errorPolicy: option(string)=?,
+        ~ssr: option(bool)=?,
+        ~displayName: option(string)=?,
+        ~skip: option(bool)=?,
+        ~onCompleted: option(Js.Nullable.t(Js.Json.t) => unit)=?,
+        ~onError: option(apolloError => unit)=?,
+        ~partialRefetch: option(bool)=?,
+        ~delay: option(bool)=?,
+        ~context: option(Js.Json.t)=?,
         ~children: renderPropObj => React.element,
       ) =>
     <JsQuery
       query=graphqlQueryAST
-      variables
-      pollInterval
-      notifyOnNetworkStatusChange
-      fetchPolicy
-      errorPolicy
-      ssr
-      displayName
-      skip
-      onCompleted
-      onError
-      partialRefetch
-      delay
-      context>
+      ?variables
+      ?pollInterval
+      ?notifyOnNetworkStatusChange
+      ?fetchPolicy
+      ?errorPolicy
+      ?ssr
+      ?displayName
+      ?skip
+      ?onCompleted
+      ?onError
+      ?partialRefetch
+      ?delay
+      ?context>
       {apolloData => apolloData |> convertJsInputToReason |> children}
     </JsQuery>;
 };

--- a/src/graphql-types/ReasonApolloSubscription.re
+++ b/src/graphql-types/ReasonApolloSubscription.re
@@ -1,4 +1,6 @@
 open ReasonApolloTypes;
+/* Silence the warning about shadowing Error from Stdlib */
+[@ocaml.warning "-45"];
 
 module Make = (Config: ReasonApolloTypes.Config) => {
   [@bs.module "graphql-tag"] external gql: ReasonApolloTypes.gql = "default";


### PR DESCRIPTION
Also, silence warning 45 in two specific locations.

Turns out there's a bug that was fixed in bucklescript master around the way optional args are generated that led to unsound bindings. Any `=?` usage needs to have an explicit `option` wrapper, as in `option(t)=?`. It's a breaking change for projects (like ReasonApollo) that were doing things the old way.

On the plus side, we can be even more confident the bindings are corrects now 😄 

Also, there's a warning about shadowing `Error` in two files, I've silenced them in their specific instances with a comment about why, so now ReasonApollo should build without any warnings or errors.