### PR TITLE
Add defaultOptions argument to createApolloClient

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -47,6 +47,7 @@ type apolloClientObjectParam = {
   ssrForceFetchDelay: option(int),
   connectToDevTools: option(bool),
   queryDeduplication: option(bool),
+  defaultOptions: option(defaultOptions),
 };
 [@bs.module "apollo-client"] [@bs.new]
 external createApolloClientJS: apolloClientObjectParam => generatedApolloClient =

--- a/src/ReasonApollo.re
+++ b/src/ReasonApollo.re
@@ -1,5 +1,31 @@
 open ApolloClient;
 
+let mapPolicies = (options, key, policies) => {
+  open ReasonApolloTypes;
+
+  let {errorPolicy, fetchPolicy} = policies;
+
+  Js.Dict.set(
+    options,
+    key,
+    Js.Dict.fromList([
+      ("errorPolicy", errorPolicyToJs(errorPolicy)),
+      ("fetchPolicy", fetchPolicyToJs(fetchPolicy)),
+    ]),
+  );
+};
+
+let makeDefaultOptions = (~mutate=?, ~query=?, ~watchQuery=?, ()) => {
+  let opts = Js.Dict.empty();
+
+  [("mutate", mutate), ("query", query), ("watchQuery", watchQuery)]
+  ->Belt.List.forEach(((key, policy)) =>
+      Belt.Option.map(policy, mapPolicies(opts, key))
+    );
+
+  opts;
+};
+
 /*
  * Expose a createApolloClient function that has to be passed to the ApolloProvider
  */
@@ -11,6 +37,7 @@ let createApolloClient =
       ~ssrForceFetchDelay=?,
       ~connectToDevTools=?,
       ~queryDeduplication=?,
+      ~defaultOptions=?,
       (),
     ) =>
   createApolloClientJS({
@@ -20,6 +47,7 @@ let createApolloClient =
     ssrForceFetchDelay,
     connectToDevTools,
     queryDeduplication,
+    defaultOptions,
   });
 // let createApolloClient =
 //     (

--- a/src/ReasonApolloTypes.re
+++ b/src/ReasonApolloTypes.re
@@ -106,3 +106,25 @@ type webSocketLinkT = {
 type documentNodeT;
 
 type splitTest = {query: documentNodeT};
+
+/* ApolloClient defaulOptions */
+
+[@bs.deriving jsConverter]
+type errorPolicy = [ | `none | `ignore | `all];
+
+[@bs.deriving jsConverter]
+type fetchPolicy = [
+  | [@bs.as "cache-first"] `cacheFirst
+  | [@bs.as "network-only"] `networkOnly
+  | [@bs.as "cache-only"] `cacheOnly
+  | [@bs.as "no-cache"] `noCache
+  | `standby
+  | [@bs.as "cache-and-network"] `cacheAndNetwork
+];
+
+type apolloDefaultOption = {
+  fetchPolicy,
+  errorPolicy,
+};
+
+type defaultOptions = Js.Dict.t(Js.Dict.t(string));


### PR DESCRIPTION
## Explanation

This is something I had to write for myself in my project as I wanted to be able to set things like `errorPolicy` to `all` but couldn't find a way to do this with the function provided. I am still pretty new so please guide me on how to write this better.

- [x] Add a `defaultOptions` argument to `ReasonApollo.createApolloClient`
- [x] Add a `makeDefaultOptions` function to create `defaultOptions`
- [ ] Test?

## Usage

The way I wrote it and I think worked for me is to use it as is:

```reason
let client = 
  ReasonApollo.(
   createApolloClient(
      ~cache=myCache
      ~link=myLink,
      ~ssrMode=true,
      ~defaultOptions=
        makeDefaultOptions(
          ~mutate={errorPolicy: `all, fetchPolicy: `cacheFirst},
          ~query={errorPolicy: `all, fetchPolicy: `cacheFirst},
          (),
    )
  );
```

That said without a test suite and my limited knowledge on the language I don't know if having this just set as an option is enough to have it work (my app has this as a required argument).

Please advise, I am more than happy to make adjustments this seems like a very simple thing we could add to be closer to 1:1 with the Js docs.