### PR TITLE
Remove bs.meth

### DIFF
--- a/src/ApolloClient.re
+++ b/src/ApolloClient.re
@@ -11,13 +11,9 @@ type mutationObj = {
 };
 
 type generatedApolloClient = {
-  query:
-    [@bs.meth] (queryObj => Js.Promise.t(ReasonApolloQuery.renderPropObjJS)),
-  mutate:
-    [@bs.meth] (
-      mutationObj => Js.Promise.t(ReasonApolloMutation.renderPropObjJS)
-    ),
-  resetStore: [@bs.meth] (unit => Js.Promise.t(unit)),
+  query: queryObj => Js.Promise.t(ReasonApolloQuery.renderPropObjJS),
+  mutate: mutationObj => Js.Promise.t(ReasonApolloMutation.renderPropObjJS),
+  resetStore: unit => Js.Promise.t(unit),
 };
 
 type fetch;


### PR DESCRIPTION
When i tried to use query function from generatedApolloClient type i got error as below:
![Zaznaczenie_006](https://user-images.githubusercontent.com/16646714/89120152-3a90ee80-d4b4-11ea-973f-7105995ba234.png)
When i remove bs.meth everything works fine. I think it is not nessesry (maybe it was when generatedApolloClient was an Js.t type, now this it is record).

