### PR TITLE
Fix readme query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ let make = () => {
     ...{({result}) =>
       switch (result) {
       | Loading => <div> {ReasonReact.string("Loading")} </div>
-      | Error(error) => <div> {ReasonReact.string(error##message)} </div>
+      | Error(error) => <div> {ReasonReact.string(error.message)} </div>
       | Data(response) =>
         <div>
           {/* Handles a deeply nested optional response */


### PR DESCRIPTION
Using version 0.9.1, I was only able to compile with `.` rather than `##`.
I guess this update was simply forgotten?

package-lock.json:
```json
    "reason-react": {
      "version": "0.9.1",
      "resolved": "https://registry.npmjs.org/reason-react/-/reason-react-0.9.1.tgz",
      "integrity": "sha512-nlH0O2TDy9KzOLOW+vlEQk4ExHOeciyzFdoLcsmmiit6hx6H5+CVDrwJ+8aiaLT/kqK5xFOjy4PS7PftWz4plA=="
    },
```
- [ ] feature
- [ ] blocking
- [X] docs